### PR TITLE
docs: add ALU design

### DIFF
--- a/docs/ALU Design.md
+++ b/docs/ALU Design.md
@@ -173,11 +173,12 @@ to an array of `i8`.
 
 Neither the Cairo VM, Cairo language nor no-std Rust have support for vectorized operations.
 
-LLVM IR has vectors as first class citizens. However,
-_vector types are [used](https://llvm.org/docs/LangRef.html#vector-type) where multiple primitive data are operated in parallel using a single instruction (SIMD)_.
-If Cairo target definition supplied to `rustc` does not suggest the existence of vector extension on
-the target platform, we would not expect any vector intrinsics to appear in the IR. Therefore,
-vector support is not planned as part of the initial phase of the project.
+LLVM IR has vectors as first class citizens. However, _vector types are
+[used](https://llvm.org/docs/LangRef.html#vector-type) where multiple primitive data are operated in
+parallel using a single instruction (SIMD)_. If Cairo target definition supplied to `rustc` does not
+suggest the existence of vector extension on the target platform, we would not expect any vector
+intrinsics to appear in the IR. Therefore, vector support is not planned as part of the initial
+phase of the project.
 
 #### Type Conversion
 


### PR DESCRIPTION
# Summary

This document captures research done in #27. ~Mostly, it's just the contents of my lengthy comment from that issue, corrected after Ara's comments. I also added a section on the statefulness (or the lack thereof).~ It's based on what we've discussed with Ara in the task comments and privately and my research mostly based on LLVM Language Reference Manual and some experiments with Godbolt generating IR from Rust. Also The Rust Book and The Cairo Book.

# Details

I still use the word _intrinsic_ everywhere because [I think it's correct usage.](https://github.com/reilabs/llvm-to-cairo/issues/27#issuecomment-2397920970), but I'm still open for debate. Maybe I don't understand something.

# Checklist

- ~[ ] Code is formatted by Rustfmt.~
- [x] Documentation has been updated if necessary.
