### PR TITLE
Rename the project to Hieratika

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hieratika-cli"
+version = "0.1.0"
+dependencies = [
+ "ariadne",
+ "clap",
+ "hieratika-compiler",
+ "itertools 0.13.0",
+ "tracing",
+]
+
+[[package]]
+name = "hieratika-compiler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bimap",
+ "chumsky",
+ "clap",
+ "derivative",
+ "downcast-rs",
+ "hieratika-errors",
+ "hieratika-flo",
+ "inkwell",
+ "itertools 0.13.0",
+ "ouroboros",
+ "tracing",
+]
+
+[[package]]
+name = "hieratika-driver"
+version = "0.1.0"
+dependencies = [
+ "ariadne",
+ "itertools 0.13.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "hieratika-errors"
+version = "0.1.0"
+dependencies = [
+ "ariadne",
+ "inkwell",
+ "thiserror",
+]
+
+[[package]]
+name = "hieratika-flo"
+version = "0.1.0"
+dependencies = [
+ "bimap",
+ "serde",
+ "serde_sexpr",
+]
+
+[[package]]
+name = "hieratika-rust-test-input"
+version = "0.1.0"
+
+[[package]]
 name = "inkwell"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,67 +332,6 @@ dependencies = [
  "regex-lite",
  "semver",
 ]
-
-[[package]]
-name = "ltc-cli"
-version = "0.1.0"
-dependencies = [
- "ariadne",
- "clap",
- "itertools 0.13.0",
- "ltc-compiler",
- "tracing",
-]
-
-[[package]]
-name = "ltc-compiler"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bimap",
- "chumsky",
- "clap",
- "derivative",
- "downcast-rs",
- "inkwell",
- "itertools 0.13.0",
- "ltc-errors",
- "ltc-flo",
- "ouroboros",
- "tracing",
-]
-
-[[package]]
-name = "ltc-driver"
-version = "0.1.0"
-dependencies = [
- "ariadne",
- "itertools 0.13.0",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ltc-errors"
-version = "0.1.0"
-dependencies = [
- "ariadne",
- "inkwell",
- "thiserror",
-]
-
-[[package]]
-name = "ltc-flo"
-version = "0.1.0"
-dependencies = [
- "bimap",
- "serde",
- "serde_sexpr",
-]
-
-[[package]]
-name = "ltc-rust-test-input"
-version = "0.1.0"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 # Here we set keys that are relevant across all packages, allowing them to be inherited.
 [workspace.package]
 version = "0.1.0"
-homepage = "https://github.com/reilabs/llvm-to-cairo"
-repository = "https://github.com/reilabs/llvm-to-cairo"
+homepage = "https://github.com/reilabs/hieratika"
+repository = "https://github.com/reilabs/hieratika"
 license-file = "LICENSE"
 
 authors = ["Reilabs"]
@@ -34,11 +34,11 @@ bimap = { version = "0.6.3", features = ["serde"] }
 clap = "4.5.16"
 inkwell = { version = "0.5.0", features = ["llvm18-0"] }
 itertools = "0.13.0"
-ltc-cli = { path = "crates/cli" }
-ltc-compiler = { path = "crates/compiler" }
-ltc-driver = { path = "crates/driver" }
-ltc-errors = { path = "crates/error" }
-ltc-flo = { path = "crates/flo" }
+hieratika-cli = { path = "crates/cli" }
+hieratika-compiler = { path = "crates/compiler" }
+hieratika-driver = { path = "crates/driver" }
+hieratika-errors = { path = "crates/error" }
+hieratika-flo = { path = "crates/flo" }
 thiserror = "1.0.63"
 tracing = "0.1.40"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# LLVM on CairoVM
+# Hieratika: Compiling LLVM to CairoVM
+
+> **hieratiká /ˌhaɪ(ə)ˈɹætɪka/**, _adjective_
+>
+> Of or pertaining to the cursive writing system that developed alongside the hieroglyphic system as
+> its handwritten counterpart for every-day use. It took the "priestly", domain-specific
+> hieroglyphics and repurposed them for non-domain-specific expression.
 
 This repository contains the efforts to enable compilation of LLVM bytecode to run on top of the
-[CairoVM](https://github.com/lambdaclass/cairo-vm) and [Starknet](https://www.starknet.io). The
-goals of this project are threefold:
+[CairoVM](https://github.com/lambdaclass/cairo-vm) and hence [Starknet](https://www.starknet.io).
+The goals of this project are threefold:
 
 1. **Provable Rust Execution:** To provide the ability to prove the execution of LLVM bytecode using
    Starknet's proving infrastructure, thereby allowing verification of said execution.

--- a/crates/README.md
+++ b/crates/README.md
@@ -2,4 +2,4 @@
 
 In order to enable flexibility and reuse of components in other projects if required, this project
 is designed as a set of component crates that assist in its operation. Please see the documentation
-of the individual crates for more information on what they encompass.
+of the individual crates for more information on what functionality they encompass.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ltc-cli"
+name = "hieratika-cli"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
 authors.workspace = true
-description = "The CLI for working with the LLVM to Cairo compilation process."
+description = "The CLI to allow users to interact with the Hieratika compilation process."
 keywords.workspace = true
 categories.workspace = true
 
@@ -16,10 +16,10 @@ rust-version.workspace = true
 [dependencies]
 ariadne.workspace = true
 clap.workspace = true
+hieratika-compiler.workspace = true
 itertools.workspace = true
-ltc-compiler.workspace = true
 tracing.workspace = true
 
 [[bin]]
-name = "ltc"         # Named for "LLVM To Cairo"
+name = "hieratika"
 path = "src/main.rs"

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,4 +1,4 @@
-# LLVM to Cairo CLI
+# Hieratika CLI
 
 This crate implements the CLI for interacting with the compiler and compilation process. It is
 primarily a user interface wrapper over the [compiler driver](../driver).

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,5 @@
 //! This is the CLI driver for the compilation of LLVM IR to Cairo. For more
-//! detail, please see the documentation for the [`ltc_compiler`] crate.
+//! detail, please see the documentation for the [`hieratika_compiler`] crate.
 
 #![warn(clippy::all, clippy::cargo, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)] // Allows for better API naming

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ltc-compiler"
+name = "hieratika-compiler"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -21,8 +21,8 @@ derivative = "2.2.0"
 downcast-rs = "1.2.1"
 inkwell.workspace = true
 itertools.workspace = true
-ltc-errors.workspace = true
-ltc-flo.workspace = true
+hieratika-errors.workspace = true
+hieratika-flo.workspace = true
 ouroboros = "0.18.4"
 tracing.workspace = true
 

--- a/crates/compiler/README.md
+++ b/crates/compiler/README.md
@@ -1,4 +1,5 @@
-# LLVM to Cairo Compiler
+# Hieratika Compiler
 
-This crate implements the full compilation behavior from LLVM IR to `FlatLowered`, but no further
-parts of the process. Those are combined using the [driver](../driver).
+This crate implements the full compilation behavior from LLVM IR to our `.flo` object format, but no
+further parts of the process. This is combined with the downstream linking and emission steps by the
+[compiler driver](../driver).

--- a/crates/compiler/input/add.ll
+++ b/crates/compiler/input/add.ll
@@ -6,9 +6,9 @@ target triple = "aarch64-unknown-none"
 @alloc_4190527422e5cc48a15bd1cb4f38f425 = private unnamed_addr constant <{ [33 x i8] }> <{ [33 x i8] c"crates/rust-test-input/src/lib.rs" }>, align 1
 @alloc_5b4544c775a23c08ca70c48dd7be27fc = private unnamed_addr constant <{ ptr, [16 x i8] }> <{ ptr @alloc_4190527422e5cc48a15bd1cb4f38f425, [16 x i8] c"!\00\00\00\00\00\00\00\05\00\00\00\05\00\00\00" }>, align 8
 
-; ltc_rust_test_input::add
+; hieratika_rust_test_input::add
 ; Function Attrs: noredzone nounwind
-define dso_local i64 @_ZN19ltc_rust_test_input3add17h828e50e9267cb510E(i64 %left, i64 %right) unnamed_addr #0 !dbg !5 {
+define dso_local i64 @_ZN19hieratika_rust_test_input3add17h828e50e9267cb510E(i64 %left, i64 %right) unnamed_addr #0 !dbg !5 {
 start:
   %right.dbg.spill = alloca [8 x i8], align 8
   %left.dbg.spill = alloca [8 x i8], align 8
@@ -51,12 +51,12 @@ attributes #3 = { noreturn nounwind }
 
 !0 = !{!"rustc version 1.81.0 (eeb90cda1 2024-09-04)"}
 !1 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !2, producer: "clang LLVM (rustc version 1.81.0 (eeb90cda1 2024-09-04))", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!2 = !DIFile(filename: "crates/rust-test-input/src/lib.rs/@/9ox3ykpp0gbrqxqlz7ajwa9w6", directory: "/Users/starfire/Development/reilabs/starkware/llvm-to-cairo")
+!2 = !DIFile(filename: "crates/rust-test-input/src/lib.rs/@/9ox3ykpp0gbrqxqlz7ajwa9w6", directory: "/Users/starfire/Development/reilabs/starkware/hieratika")
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
-!5 = distinct !DISubprogram(name: "add", linkageName: "_ZN19ltc_rust_test_input3add17h828e50e9267cb510E", scope: !7, file: !6, line: 4, type: !8, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, templateParams: !14, retainedNodes: !11)
-!6 = !DIFile(filename: "crates/rust-test-input/src/lib.rs", directory: "/Users/starfire/Development/reilabs/starkware/llvm-to-cairo", checksumkind: CSK_MD5, checksum: "178b5b568f49bd1e17834a7529756af1")
-!7 = !DINamespace(name: "ltc_rust_test_input", scope: null)
+!5 = distinct !DISubprogram(name: "add", linkageName: "_ZN19hieratika_rust_test_input3add17h828e50e9267cb510E", scope: !7, file: !6, line: 4, type: !8, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, templateParams: !14, retainedNodes: !11)
+!6 = !DIFile(filename: "crates/rust-test-input/src/lib.rs", directory: "/Users/starfire/Development/reilabs/starkware/hieratika", checksumkind: CSK_MD5, checksum: "178b5b568f49bd1e17834a7529756af1")
+!7 = !DINamespace(name: "hieratika_rust_test_input", scope: null)
 !8 = !DISubroutineType(types: !9)
 !9 = !{!10, !10, !10}
 !10 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)

--- a/crates/compiler/src/context/mod.rs
+++ b/crates/compiler/src/context/mod.rs
@@ -1,8 +1,8 @@
 //! Contains the source compilation context, which is a way of tracking the
 //! compilation units being processed by the compiler.
 
+use hieratika_errors::compile::{Error, Result};
 use inkwell::{context::Context as LLVMContext, module::Module};
-use ltc_errors::compile::{Error, Result};
 use ouroboros::self_referencing;
 
 pub mod module;

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -50,8 +50,8 @@ pub mod llvm;
 pub mod pass;
 pub mod polyfill;
 
-use ltc_errors::compile::{Error, Result};
-use ltc_flo::FlatLoweredObject;
+use hieratika_errors::compile::{Error, Result};
+use hieratika_flo::FlatLoweredObject;
 
 use crate::{
     context::SourceContext,
@@ -62,8 +62,8 @@ use crate::{
 /// Handles the compilation of LLVM IR to our [`FlatLoweredObject`] object
 /// format.
 ///
-/// In the context of LLVM to Cairo, compilation refers to the process of
-/// translating from [LLVM IR](https://llvm.org/docs/LangRef.html) to our
+/// In the context of the Hieratika project, compilation refers to the process
+/// of translating from [LLVM IR](https://llvm.org/docs/LangRef.html) to our
 /// internal `FLO` object file format.
 ///
 /// LLVM IR is designed around a virtual processor model that is expected to
@@ -144,8 +144,8 @@ impl Compiler {
     ///
     /// # Errors
     ///
-    /// - [`ltc_errors::compile::Error`] if the compilation process fails for
-    ///   any reason.
+    /// - [`hieratika_errors::compile::Error`] if the compilation process fails
+    ///   for any reason.
     pub fn run(mut self) -> Result<CompilationResult> {
         let PassManagerReturnData {
             context: _context,

--- a/crates/compiler/src/llvm/data_layout.rs
+++ b/crates/compiler/src/llvm/data_layout.rs
@@ -6,7 +6,7 @@ use chumsky::{
     prelude::{choice, just},
     Parser,
 };
-use ltc_errors::compile::{Error, Result};
+use hieratika_errors::compile::{Error, Result};
 
 use crate::constant::{
     BYTE_SIZE,

--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::{Display, Formatter};
 
+use hieratika_errors::{compile, compile::Error};
 use inkwell::types::{
     AnyTypeEnum,
     ArrayType,
@@ -16,7 +17,6 @@ use inkwell::types::{
     VoidType,
 };
 use itertools::Itertools;
-use ltc_errors::{compile, compile::Error};
 
 use crate::constant::BYTE_SIZE;
 

--- a/crates/compiler/src/pass/analysis/module_map.rs
+++ b/crates/compiler/src/pass/analysis/module_map.rs
@@ -8,12 +8,12 @@
 
 use std::collections::HashMap;
 
+use hieratika_errors::compile::{Error, Result};
 use inkwell::{
     module::{Linkage, Module},
     values::{FunctionValue, GlobalValue},
     GlobalVisibility,
 };
-use ltc_errors::compile::{Error, Result};
 
 use crate::{
     context::SourceContext,
@@ -439,7 +439,9 @@ mod test {
 
         // Functions, though technically globals, should not be seen
         assert!(
-            !globals.contains_key(&"_ZN19ltc_rust_test_input3add17h828e50e9267cb510E".to_string())
+            !globals.contains_key(
+                &"_ZN19hieratika_rust_test_input3add17h828e50e9267cb510E".to_string()
+            )
         );
         assert!(!globals.contains_key(&"llvm.dbg.declare".to_string()));
         assert!(!globals.contains_key(&"llvm.uadd.with.overflow.i64".to_string()));
@@ -506,9 +508,9 @@ mod test {
         assert!(!functions.contains_key(&"alloc_4190527422e5cc48a15bd1cb4f38f425".to_string()));
         assert!(!functions.contains_key(&"alloc_5b4544c775a23c08ca70c48dd7be27fc".to_string()));
 
-        // _ZN19ltc_rust_test_input3add17h828e50e9267cb510E
+        // _ZN19hieratika_rust_test_input3add17h828e50e9267cb510E
         let rust_test_input = functions
-            .get(&"_ZN19ltc_rust_test_input3add17h828e50e9267cb510E".to_string())
+            .get(&"_ZN19hieratika_rust_test_input3add17h828e50e9267cb510E".to_string())
             .unwrap();
         assert!(!rust_test_input.intrinsic);
         assert_eq!(rust_test_input.kind, TopLevelEntryKind::Definition);

--- a/crates/compiler/src/pass/mod.rs
+++ b/crates/compiler/src/pass/mod.rs
@@ -30,7 +30,7 @@
 //! The implementations in this file are deliberately left incomplete, and exist
 //! only as skeletons to serve the purposes of correctly designing the compiler
 //! state. A proper implementation will take place later in the project, as
-//! tracked by [#56](https://github.com/reilabs/llvm-to-cairo/issues/56).
+//! tracked by [#56](https://github.com/reilabs/hieratika/issues/56).
 
 pub mod analysis;
 pub mod data;
@@ -41,7 +41,7 @@ use std::{
 };
 
 use downcast_rs::Downcast;
-use ltc_errors::compile::{Error, Result};
+use hieratika_errors::compile::{Error, Result};
 
 use crate::{
     context::SourceContext,

--- a/crates/compiler/src/polyfill/mod.rs
+++ b/crates/compiler/src/polyfill/mod.rs
@@ -102,7 +102,7 @@ impl PolyfillMap {
     /// fully resolved before calling this.
     ///
     /// ```
-    /// use ltc_compiler::polyfill::PolyfillMap;
+    /// use hieratika_compiler::polyfill::PolyfillMap;
     ///
     /// let opcode_name = "add";
     /// let arg_types = vec!["i8", "i64"];

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ltc-driver"
+name = "hieratika-driver"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/driver/README.md
+++ b/crates/driver/README.md
@@ -1,4 +1,4 @@
-# LLVM to Cairo Compiler Driver
+# Hieratika Compiler Driver
 
 The compiler driver is responsible for marrying up the compilation process that we control with the
 further parts of the Cairo compilation pipeline. This includes generating and checking Sierra, and

--- a/crates/error/Cargo.toml
+++ b/crates/error/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ltc-errors"
+name = "hieratika-errors"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
 authors.workspace = true
-description = "The error types used by the LLVM to Cairo project."
+description = "The error types used by the Hieratika project."
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/error/README.md
+++ b/crates/error/README.md
@@ -1,4 +1,4 @@
-# LLVM to Cairo Errors
+# Hieratika Errors
 
 Strongly-typed errors that can be used by multiple crates, therefore simplifying error handling
 throughout the project.

--- a/crates/flo/Cargo.toml
+++ b/crates/flo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ltc-flo"
+name = "hieratika-flo"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
 authors.workspace = true
-description = "The FlatLowered Object format, or FLO, is a FlatLowered-like object format customized to the needs of the LTC project."
+description = "The FlatLowered Object format, or FLO, is a FlatLowered-like object format customized to the needs of the Hieratika project."
 keywords.workspace = true
 categories.workspace = true
 
@@ -14,6 +14,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+bimap.workspace = true
 serde = { version = "1.0.210", features = ["derive"] }
 serde_sexpr = "0.1.0"
-bimap.workspace = true

--- a/crates/flo/README.md
+++ b/crates/flo/README.md
@@ -1,14 +1,14 @@
 # `FlatLowered` Intermediate Representation
 
-The `FlatLowered` Object format (`FLO`) is an intermediate representation for the LLVM to Cairo
-project that is based on Cairo's `FlatLowered` but tailored for our use-case.
+The `FlatLowered` Object format (`FLO`) is an intermediate representation for the Hieratika project
+that is based on Cairo's `FlatLowered` but tailored for our use-case.
 
 In particular, it removes any dependency on the [Salsa](https://github.com/salsa-rs/salsa) database
 structures, as well as:
 
 - Allowing round-tripping to and from `FlatLowered`.
 - Forming the basis of the `.flo` (FlatLowered Object) object format for exchange between tools in
-  the LTC pipeline.
+  the Hieratika pipeline.
 - Adding support for features (such as linkage and relocations) that are not supported by the
   `FlatLowered`.
 

--- a/crates/rust-test-input/Cargo.toml
+++ b/crates/rust-test-input/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ltc-rust-test-input"
+name = "hieratika-rust-test-input"
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/docs/ALU Design.md
+++ b/docs/ALU Design.md
@@ -1,7 +1,7 @@
 # ALU Design
 
 This document describes the research done for
-[#27 Design ALU](https://github.com/reilabs/llvm-to-cairo/issues/27).
+[#27 Design ALU](https://github.com/reilabs/hieratika/issues/27).
 
 The first part, [**Research**](#Research), describes selected features of LLVM IR, Rust and Cairo
 (both the virtual machine and the programming language), that impact the way we must handle
@@ -58,7 +58,7 @@ behavior, i.e. no (un)signed overflow. However, if the operands cause the overfl
 returns a poison, which is an equivalent of a value indicating undefined behavior that can propagate
 throughout the program.
 
-[According to the experiment](https://github.com/reilabs/llvm-to-cairo/issues/27#issuecomment-2397645979),
+[According to the experiment](https://github.com/reilabs/hieratika/issues/27#issuecomment-2397645979),
 LLVM does not seem to emit such instructions from the Rust code, so the initial version of ALU will
 not handle `nuw`, `nsw` or other keywords in any specific way.
 
@@ -76,7 +76,7 @@ the `call` instruction. The intrinsic is defined in the LLVM codebase and its so
 make it into the `.ll` file produced out of the adding operation in Rust code.
 
 The LLVM Language Reference Manual has an extensive list of intrinsics. Here's the example of
-[`llvm.uadd.with.overflow.<ty>`](https://llvm.org/docs/LangRef.html#llvm-uadd-with-overflow-intrinsics).
+[ `llvm.uadd.with.overflow.<ty>`](https://llvm.org/docs/LangRef.html#llvm-uadd-with-overflow-intrinsics).
 
 ### Data Types
 
@@ -212,14 +212,14 @@ two general purpose registers or the result of the last operation stored in anot
 a flag register, where specific bits signal certain conditions (e.g. the result being zero or an
 integer overflow).
 
-The LLVM-to-Cairo infrastructure needs to deliver pieces of code translating generic LLVM arithmetic
+The Hieratika infrastructure needs to deliver pieces of code translating generic LLVM arithmetic
 operations to their counterparts specific to the Cairo VM architecture. This translation will be
-done on the code level, during one of the LLVM-to-Cairo pipeline stages. Namely, this will be not
+done on the code level, during one of the Hieratika pipeline stages. Namely, this will be not
 runtime translation, but rather a compilation time one. Therefore, there is no global state to be
 managed during that time.
 
 Additionally, it has been noticed
-[in one of the experiments](https://github.com/reilabs/llvm-to-cairo/issues/27#issuecomment-2391893640),
+[in one of the experiments](https://github.com/reilabs/hieratika/issues/27#issuecomment-2391893640),
 that LLVM IR follows the same principle of not managing the internal state of arithmetic operations.
 This is either done by:
 
@@ -252,7 +252,7 @@ implement the desired behavior, e.g. to make sure we indicate overflow on obviou
 
 The ALU will be implemented as source code written in
 [Cairo](https://book.cairo-lang.org/title-page.html). During the
-[LLVM-to-Cairo compilation pipeline](https://www.notion.so/reilabs/System-Architecture-113d2f80c874802b8480d997347933a2?pvs=4)
+[Hieratika compilation pipeline](https://www.notion.so/reilabs/System-Architecture-113d2f80c874802b8480d997347933a2?pvs=4)
 the polyfills implementations will be translated to `FlatLowered` objects and then extracted to
 `.flo` files. Then, on the linking phase, all the `.flo` files (those created from arithmetic
 operations implementations and those from the LLVM IR) will be linked together.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-This document exists as a brief introduction to how you can contribute to the LLVM to Cairo project.
-It includes a guide to [getting started](#setting-up-for-development) and
+This document exists as a brief introduction to how you can contribute to the Hieratika project. It
+includes a guide to [getting started](#setting-up-for-development) and
 [contributing to `main`](#getting-your-work-on-main).
 
 This repository is written in [Rust](https://www.rust-lang.org), a high-performance and low-level
@@ -29,17 +29,17 @@ We assume that you are either running on linux or macOS at this stage.
 2. Clone the repository. If you don't want to contribute directly you can use HTTPS clones:
 
    ```shell
-   git clone https://github.com/reilabs/llvm-to-cairo
+   git clone https://github.com/reilabs/hieratika
    ```
 
    If you _do_ want to contribute directly to the tree, we recommend cloning over SSH:
 
    ```shell
-   git clone git@github.com:reilabs/llvm-to-cairo.git
+   git clone git@github.com:reilabs/hieratika.git
    ```
 
-3. Enter the cloned directory (`cd llvm-to-cairo`) and launch a development shell using
-   `nix develop`. This will launch into your default shell, but you can override this by running
+3. Enter the cloned directory (`cd hieratika`) and launch a development shell using `nix develop`.
+   This will launch into your default shell, but you can override this by running
    `nix develop ".#ci" --command <your-command>` to use the CI dev shell instead.
 
 4. Within this shell you are able to run Cargo commands such as `cargo build`, which will build the
@@ -86,8 +86,8 @@ seems to have issues with these.
 ## Getting Your Work on `main`
 
 For contributions this repository works on a
-[Pull Request](https://github.com/reilabs/llvm-to-cairo/pulls) and subsequent review model,
-supported by CI to check that things avoid being broken. The process works as follows:
+[Pull Request](https://github.com/reilabs/hieratika/pulls) and subsequent review model, supported by
+CI to check that things avoid being broken. The process works as follows:
 
 1. If necessary, you fork the repository, but if you have access please create a branch.
 2. You make your changes on that branch.

--- a/docs/LLVM IR Generation Features.md
+++ b/docs/LLVM IR Generation Features.md
@@ -64,8 +64,6 @@ To get the list of all flags `opt` accepts, without arch-specific options, call 
 $ opt -help | grep -ivE 'aarch64|amdgpu|arm|avr|hexagon|mips|msp430|nvptx|ppc|r600|riscv|si|systemz|wasm|x86'
 ```
 
-```
-
 On my machine (LLVM version 18.1.8 aarch64-apple-darwin23.6.0) this command returns 463 different
 flags.
 
@@ -133,4 +131,3 @@ require its own detailed research to understand fully.
 
 By understanding and utilizing these passes effectively, we can optimize the compilation process,
 resulting in efficient and performant executable binaries.
-```

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 # A flake that sets up the necessary development environment for things.
 {
-  description = "LLVM to CairoVM";
+  description = "Hieratika: Compiling LLVM to CairoVM";
 
   # The things that we want to pin to.
   inputs = {
@@ -60,13 +60,13 @@
         };
 
         # Filter out things that aren't derivations for the `packages` output, or Nix gets mad.
-        llvmToCairo = lib.filterAttrs (lib.const lib.isDerivation) workspacePackages;
+        hieratika = lib.filterAttrs (lib.const lib.isDerivation) workspacePackages;
 
         # And for convenience, collect all the workspace members into a single derivation,
         # so we can check they all compile with one command, `nix build '.#all'`.
         all = pkgs.symlinkJoin {
-          name = "llvm-to-cairo-all";
-          paths = lib.attrValues llvmToCairo;
+          name = "hieratika-all";
+          paths = lib.attrValues hieratika;
         };
 
         # We get your default shell to make sure things feel familiar in the dev shell.
@@ -83,13 +83,13 @@
       in {
         packages = {
           inherit all;
-          default = llvmToCairo.ltc-cli;
-        } // llvmToCairo;
+          default = hieratika.hieratika-cli;
+        } // hieratika;
 
         # The default dev shell puts you in your native shell to make things feel happy.
         devShells.default = craneLib.devShell {
           LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
-          inputsFrom = lib.attrValues llvmToCairo;
+          inputsFrom = lib.attrValues hieratika;
           packages = devshellPackages;
 
           shellHook = ''
@@ -100,7 +100,7 @@
         # The dev shell for CI allows it to interpret commands properly.
         devShells.ci = craneLib.devShell {
           LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
-          inputsFrom = lib.attrValues llvmToCairo;
+          inputsFrom = lib.attrValues hieratika;
           packages = devshellPackages;
         };
       }

--- a/workspace.nix
+++ b/workspace.nix
@@ -21,8 +21,8 @@
   # Attrsets in this will add additional arguments to craneLib.buildPackage for the
   # crate with the matching package name.
   crateSpecificArgs = {
-    ltc-cli = {
-      meta.mainProgram = "ltc";
+    hieratika = {
+      meta.mainProgram = "hieratika";
     };
   };
 
@@ -53,7 +53,7 @@
   # separately, and thus only build them once for the whole workspace.
   workspaceDeps = craneLib.buildDepsOnly (commonArgs // {
     # Workspaces don't have names, so we'll give it the repo name for the dependencies.
-    pname = "llvm-to-cairo-deps";
+    pname = "hieratika-deps";
     inherit version;
   });
 


### PR DESCRIPTION
# Summary

As decided upon by the team, this is the official and much more catchy name for this project. The reasoning behind the choice is provided in the README.

This commit changes all references to "ltc", "llvm-to-cairo", or "LLVM to Cairo" to instead refer to the new name.

# Details

I've done my best with searches both manually and with `rg`, but please check through things to ensure there are no further references to "ltc", "llvm-to-cairo", or "LLVM to Cairo" in the codebase except where it makes sense (in the title).

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
