### PR TITLE
Elevate warnings to errors on CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+# Metadata for the actions workflow
+name: "Docs CI"
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+# Environment variables that will be set on all runners
+env:
+  DEV_SHELL_LINUX: "nix --store ~/nix_store develop '.#ci'"
+  DEV_SHELL_MACOS: "nix develop '.#ci'"
+
+# Configuration for individual jobs
+jobs:
+  # This job checks the formatting of the code and other artifacts.
+  formatting:
+    name: "Check Docs Formatting"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Install Lix
+        shell: bash
+        run: |
+          curl -sSf -L https://install.lix.systems/lix | sh -s -- install --no-confirm
+      - name: Restore Nix Cache
+        uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: |
+            ~/nix_store
+          key: nix-${{ hashFiles('**/flake.lock') }}-ubuntu-latest
+      - name: Build Lix Dependencies
+        shell: bash
+        run: |
+          ${{ env.DEV_SHELL_LINUX }}
+      - name: Install Node Deps
+        shell: bash
+        run: |
+          ${{ env.DEV_SHELL_LINUX }} --command npm install
+      - name: Lint Documentation
+        shell: bash
+        run: |
+          ${{ env.DEV_SHELL_LINUX }} --command npx prettier --check .
+
+  licensing:
+    name: "Check Licenses"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          manifest-path: ./Cargo.toml
+          command: check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,5 @@
 # Metadata for the actions workflow
-name: CI
+name: "Rust CI"
 on:
   push:
     branches: ["main"]
@@ -13,12 +13,14 @@ env:
   CARGO_TERM_COLOR: always # Always colour Cargo's output.
   CARGO_INCREMENTAL: 0 # Always run without incremental builds on CI.
   CARGO_PROFILE_DEV_DEBUG: 0 # Don't embed debug info even though the build is a dev build.
+  RUSTFLAGS: "-D warnings" # Elevate warnings to errors so clippy will fail CI.
+  RUSTDOCFLAGS: "-D warnings" # Elevate warnings to errors so clippy will fail CI.
 
 # Configuration for individual jobs
 jobs:
   # This job is responsible for running the unit and integration tests
   test:
-    name: "Test"
+    name: "Test Rust Code"
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +73,7 @@ jobs:
 
   # This job runs the linter.
   lint:
-    name: "Lint Code"
+    name: "Lint Rust Code"
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Code
@@ -105,7 +107,7 @@ jobs:
 
   # This job checks the formatting of the code and other artifacts.
   formatting:
-    name: "Check Formatting"
+    name: "Check Rust Formatting"
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Code
@@ -136,22 +138,36 @@ jobs:
         shell: bash
         run: |
           ${{ env.DEV_SHELL_LINUX }} --command cargo fmt --all -- --check
-      - name: Install Node Deps
-        shell: bash
-        run: |
-          ${{ env.DEV_SHELL_LINUX }} --command npm install
-      - name: Lint Documentation
-        shell: bash
-        run: |
-          ${{ env.DEV_SHELL_LINUX }} --command npx prettier --check .
 
-  licensing:
-    name: "Check Licenses"
+  documentation:
+    name: "Check Rust Documentation"
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - name: Install Lix
+        shell: bash
+        run: |
+          curl -sSf -L https://install.lix.systems/lix | sh -s -- install --no-confirm
+      - name: Restore Nix Cache
+        uses: actions/cache@v3
+        continue-on-error: true
         with:
-          manifest-path: ./Cargo.toml
-          command: check
+          path: |
+            ~/nix_store
+          key: nix-${{ hashFiles('**/flake.lock') }}-ubuntu-latest
+      - name: Restore Rust Cache
+        uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: |
+            target/
+          key: rust-${{ hashFiles('**/Cargo.lock') }}-ubuntu-latest
+      - name: Build Lix Dependencies
+        shell: bash
+        run: |
+          ${{ env.DEV_SHELL_LINUX }}
+      - name: Check Documentation
+        shell: bash
+        run: |
+          ${{ env.DEV_SHELL_LINUX }} --command cargo doc --document-private-items

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -110,7 +110,6 @@ use crate::{
 ///
 /// We fully expect to modify the process in the future to target `Sierra`
 /// directly, giving us more control as we need it.
-#[allow(dead_code)]
 pub struct Compiler {
     /// The source context, containing references to the LLVM module to be
     /// compiled.

--- a/crates/compiler/src/llvm/data_layout.rs
+++ b/crates/compiler/src/llvm/data_layout.rs
@@ -766,6 +766,7 @@ mod test {
     };
 
     #[test]
+    #[allow(clippy::too_many_lines)] // We don't care as it's a test
     fn can_parse_data_layout() {
         let dl_string = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128";
 
@@ -901,6 +902,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)] // We don't care as it's a test
     fn can_parse_data_layout_to_default() {
         let dl_string = "";
 

--- a/crates/compiler/src/llvm/special_intrinsics.rs
+++ b/crates/compiler/src/llvm/special_intrinsics.rs
@@ -108,16 +108,16 @@ mod test {
 
     #[test]
     fn contains_dbg_declare() {
-        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.declare"))
+        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.declare"));
     }
 
     #[test]
     fn contains_dbg_value() {
-        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.value"))
+        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.value"));
     }
 
     #[test]
     fn contains_dbg_assign() {
-        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.assign"))
+        assert!(SpecialIntrinsics::new().intrinsics.contains_key("llvm.dbg.assign"));
     }
 }


### PR DESCRIPTION
# Summary

This makes sure that clippy lints will cause the linting CI pipeline to fail, and also ensures the same for the newly added docs checking pipeline.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
