### PR TITLE
flo: switch to more up-to-date sexpr library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
- "version_check 0.9.5",
+ "version_check",
  "zerocopy",
 ]
 
@@ -251,7 +251,7 @@ version = "0.1.0"
 dependencies = [
  "bimap",
  "serde",
- "serde_sexpr",
+ "serde-lexpr",
 ]
 
 [[package]]
@@ -308,10 +308,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexpr"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a84de6a9df442363b08f5dbf0cd5b92edc70097b89c4ce4bfea4679fe48bc67"
+dependencies = [
+ "itoa",
+ "lexpr-macros",
+ "ryu",
+]
+
+[[package]]
+name = "lexpr-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b5cb8bb985c81a8ac1a0f8b5c4865214f574ddd64397ef7a99c236e21f35bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "libc"
@@ -331,22 +358,6 @@ dependencies = [
  "libc",
  "regex-lite",
  "semver",
-]
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check 0.1.5",
 ]
 
 [[package]]
@@ -404,7 +415,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.82",
- "version_check 0.9.5",
+ "version_check",
  "yansi",
 ]
 
@@ -433,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-lexpr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4cda13396159f59e7946118cdac0beadeecfb7cf76b197f4147e546f4ead6f"
+dependencies = [
+ "lexpr",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,16 +483,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.82",
-]
-
-[[package]]
-name = "serde_sexpr"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5318bfeed779c64075ce317c81462ed54dc00021be1c6b34957d798e11a68bdb"
-dependencies = [
- "nom",
- "serde",
 ]
 
 [[package]]
@@ -589,12 +606,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/crates/flo/Cargo.toml
+++ b/crates/flo/Cargo.toml
@@ -16,4 +16,4 @@ rust-version.workspace = true
 [dependencies]
 bimap.workspace = true
 serde = { version = "1.0.210", features = ["derive"] }
-serde_sexpr = "0.1.0"
+serde-lexpr = "0.1.0"

--- a/crates/flo/src/flo.rs
+++ b/crates/flo/src/flo.rs
@@ -219,10 +219,10 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to deserialize a partial
+    /// - [`serde_lexpr::Error`] if it is not possible to deserialize a partial
     ///   `FlatLoweredObject` from the provided `encoded` string.
-    pub fn from_str_partial(encoded: &str) -> serde_sexpr::Result<Self> {
-        serde_sexpr::from_str(encoded)
+    pub fn from_str_partial(encoded: &str) -> serde_lexpr::Result<Self> {
+        serde_lexpr::from_str(encoded)
     }
 
     /// Reads a .flo file from the provided reader, and generates an in-memory
@@ -234,10 +234,10 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to deserialize a partial
+    /// - [`serde_lexpr::Error`] if it is not possible to deserialize a partial
     ///   `FlatLoweredObject` from the provided `reader`.
-    pub fn read_partial(reader: impl Read) -> serde_sexpr::Result<Self> {
-        serde_sexpr::from_reader(reader)
+    pub fn read_partial(reader: impl Read) -> serde_lexpr::Result<Self> {
+        serde_lexpr::from_reader(reader)
     }
 
     /// Reads a .flo file from the filesystem, and generates our in-memory
@@ -249,11 +249,11 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to deserialize a partial
+    /// - [`serde_lexpr::Error`] if it is not possible to deserialize a partial
     ///   `FlatLoweredObject` from the file at the provided `filename`.
-    pub fn read_partial_from_file(filename: &str) -> serde_sexpr::Result<Self> {
+    pub fn read_partial_from_file(filename: &str) -> serde_lexpr::Result<Self> {
         let reader = File::open(filename)?;
-        serde_sexpr::from_reader(reader)
+        serde_lexpr::from_reader(reader)
     }
 
     /// Reads a .flo file from the provided `reader`, and generates an in-memory
@@ -261,9 +261,9 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to deserialize a
+    /// - [`serde_lexpr::Error`] if it is not possible to deserialize a
     ///   `FlatLoweredObject` from the provided `reader`.
-    pub fn read(reader: impl Read) -> serde_sexpr::Result<Self> {
+    pub fn read(reader: impl Read) -> serde_lexpr::Result<Self> {
         let flo = Self::read_partial(reader)?;
         flo.panic_on_unexpected_poison();
 
@@ -275,9 +275,9 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to deserialize a
+    /// - [`serde_lexpr::Error`] if it is not possible to deserialize a
     ///   `FlatLoweredObject` from the file at the provided `filename.`
-    pub fn read_from_file(filename: &str) -> serde_sexpr::Result<Self> {
+    pub fn read_from_file(filename: &str) -> serde_lexpr::Result<Self> {
         let flo = Self::read_partial_from_file(filename)?;
         flo.panic_on_unexpected_poison();
 
@@ -289,44 +289,44 @@ impl FlatLoweredObject {
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to serialize `self` to a
+    /// - [`serde_lexpr::Error`] if it is not possible to serialize `self` to a
     ///   string.
-    pub fn to_str(&self) -> serde_sexpr::Result<String> {
+    pub fn to_str(&self) -> serde_lexpr::Result<String> {
         self.panic_on_unexpected_poison();
-        serde_sexpr::to_string(&self)
+        serde_lexpr::to_string(&self)
     }
 
     /// Writes the `FlatLoweredObject` to the provided `writer`.
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to write `self` to the
+    /// - [`serde_lexpr::Error`] if it is not possible to write `self` to the
     ///   provided `writer`.
-    pub fn write(&self, writer: impl Write) -> serde_sexpr::Result<()> {
+    pub fn write(&self, writer: impl Write) -> serde_lexpr::Result<()> {
         self.panic_on_unexpected_poison();
-        serde_sexpr::to_writer(writer, &self)
+        serde_lexpr::to_writer(writer, &self)
     }
 
     /// Writes the `FlatLoweredObject` to the file at the provided `filename`.
     ///
     /// # Errors
     ///
-    /// - [`serde_sexpr::Error`] if it is not possible to write `self` to a
+    /// - [`serde_lexpr::Error`] if it is not possible to write `self` to a
     ///   file.
-    pub fn write_to_file(&self, filename: &str) -> serde_sexpr::Result<()> {
+    pub fn write_to_file(&self, filename: &str) -> serde_lexpr::Result<()> {
         self.panic_on_unexpected_poison();
 
         let writer = File::create(filename)?;
-        serde_sexpr::to_writer(writer, &self)
+        serde_lexpr::to_writer(writer, &self)
     }
 }
 
 impl FromStr for FlatLoweredObject {
-    type Err = serde_sexpr::Error;
+    type Err = serde_lexpr::Error;
 
     /// Creates a new `FlatLoweredObject` representation from a string
     /// representation; for example, from a string read from a .flo file.
-    fn from_str(encoded: &str) -> serde_sexpr::Result<Self> {
+    fn from_str(encoded: &str) -> serde_lexpr::Result<Self> {
         let flo = Self::from_str_partial(encoded)?;
         flo.panic_on_unexpected_poison();
 


### PR DESCRIPTION
# Summary

This switches from the `serde_sexpr` crate to the more up-to-date `serde-lexpr` crate.