### PR TITLE
Tweak the FLO representation for easier building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
 name = "hieratika-flo"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bimap",
  "serde",
  "serde-lexpr",

--- a/crates/flo/Cargo.toml
+++ b/crates/flo/Cargo.toml
@@ -17,3 +17,6 @@ rust-version.workspace = true
 bimap.workspace = true
 serde = { version = "1.0.210", features = ["derive"] }
 serde-lexpr = "0.1.0"
+
+[dev-dependencies]
+anyhow.workspace = true

--- a/crates/flo/src/builders.rs
+++ b/crates/flo/src/builders.rs
@@ -36,7 +36,7 @@ use crate::{
 #[derive(Debug)]
 pub struct BlockBuilder<'a> {
     /// The `FlatLoweredObject` context in which this block is being built.
-    context: &'a mut FlatLoweredObject,
+    pub context: &'a mut FlatLoweredObject,
 
     /// The block object actively being built.
     block: Block,
@@ -234,12 +234,13 @@ impl<'a> BlockBuilder<'a> {
     /// * `value` - The constant value to be assigned.
     pub fn assign_new_const(
         &mut self,
-        typ: Type,
         value: ConstantValue,
         diagnostics: Vec<DiagnosticId>,
         location: Option<LocationId>,
     ) -> StatementId {
-        let variable = self.context.add_variable_with_diagnostics(typ, vec![], location);
+        let variable =
+            self.context
+                .add_variable_with_diagnostics(value.typ.clone(), vec![], location);
         self.assign_const(variable, value, diagnostics, location);
 
         variable
@@ -265,8 +266,8 @@ impl<'a> BlockBuilder<'a> {
     ///
     /// * `typ` -  The type of the variable to be created.
     /// * `value` - The constant value to be assigned.
-    pub fn simple_assign_new_const(&mut self, typ: Type, value: ConstantValue) -> VariableId {
-        let variable = self.context.add_variable(typ);
+    pub fn simple_assign_new_const(&mut self, value: ConstantValue) -> VariableId {
+        let variable = self.context.add_variable(value.typ.clone());
         self.assign_const(variable, value, vec![], None);
 
         variable

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -397,8 +397,8 @@ pub enum Type {
     Snapshot(Box<Type>),
 
     /// Composite types.
-    Array(ArrayTypeId),
-    Struct(StructTypeId),
+    Array(ArrayType),
+    Struct(StructType),
 
     /// **For Internal Use:** Indicates that this Variable's type is
     /// unspecified, e.g. as part of a poisoned [`Variable`].
@@ -429,7 +429,7 @@ impl Type {
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ArrayType {
     /// The single type of all members in the type.
-    pub member_type: Type,
+    pub member_type: Box<Type>,
 
     /// The length of the array, in elements.
     pub length: usize,


### PR DESCRIPTION
# Summary

This commit alters the `FLO` object format representation in some small ways to make it easier to build object file output in the hieratika compiler. It provides access to the context from within the builder for more in-depth modifications, and also changes the type representation subtly to make it less complex.

# Details

Just a sanity check, please!

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
