### PR TITLE
Perform partial compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,36 +43,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -99,6 +99,12 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -154,9 +160,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "derivative"
@@ -180,6 +186,23 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "ethnum"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -218,11 +241,13 @@ dependencies = [
  "clap",
  "derivative",
  "downcast-rs",
+ "ethnum",
  "hieratika-errors",
  "hieratika-flo",
  "inkwell",
  "itertools 0.13.0",
  "ouroboros",
+ "rand",
  "tracing",
 ]
 
@@ -281,7 +306,7 @@ checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -389,14 +414,23 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -415,7 +449,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "version_check",
  "yansi",
 ]
@@ -436,6 +470,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -483,7 +547,7 @@ checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -502,7 +566,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -530,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -556,7 +620,7 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -578,7 +642,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -615,13 +679,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -708,6 +769,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -719,5 +781,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1.0.89"
 ariadne = "0.4.1"
 bimap = { version = "0.6.3", features = ["serde"] }
 clap = "4.5.16"
+ethnum = "1.5.0"
 inkwell = { version = "0.5.0", features = ["llvm18-0"] }
 itertools = "0.13.0"
 hieratika-cli = { path = "crates/cli" }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -19,12 +19,14 @@ chumsky = "0.9.3"
 clap.workspace = true
 derivative = "2.2.0"
 downcast-rs = "1.2.1"
+ethnum.workspace = true
 inkwell.workspace = true
 itertools.workspace = true
 hieratika-errors.workspace = true
 hieratika-flo.workspace = true
 ouroboros = "0.18.4"
 tracing.workspace = true
+rand = "0.8.5"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -11,6 +11,34 @@
 //! 2. To enable use of libraries written in such languages as part of the Cairo
 //!    ecosystem (e.g. from a contract written in Cairo itself).
 //!
+//! Using the compiler API is very simple, as illustrated by the following
+//! example:
+//!
+//! ```rust
+//! use std::path::Path;
+//!
+//! use hieratika_compiler::{context::SourceContext, CompilerBuilder};
+//! use hieratika_flo::FlatLoweredObject;
+//!
+//! fn main() -> anyhow::Result<()> {
+//!     // We start by prepping the source, and the source context to hold it.
+//!     let llvm_ir_path = "input/add.ll";
+//!     let source_path = Path::new(llvm_ir_path);
+//!     let ctx = SourceContext::create(source_path)?;
+//!
+//!     // We then need to build the compiler itself. This can take additional
+//!     // options to specify a pass configuration or a polyfill configuration
+//!     // as needed.
+//!     let compiler = CompilerBuilder::new(ctx).build();
+//!
+//!     // With that done, we can execute the compiler, which will process the
+//!     // provided LLVM IR into an FLO object.
+//!     let result: FlatLoweredObject = compiler.run()?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
 //! # Process Overview
 //!
 //! While more information can be found in the module-level documentation of
@@ -18,15 +46,41 @@
 //! be stated as follows:
 //!
 //! 1. We ingest LLVM IR in textual format.
-//! 2. We translate that LLVM IR to a combination of Cairo's internal IR, and
-//!    invocation of polyfills for operations that our target CPU does not
-//!    support.
-//! 3. We optimize those polyfills to achieve better performance.
+//! 2. We translate that LLVM IR to a combination of our [`hieratika_flo`]
+//!    object format, and the invocation of polyfills for operations that our
+//!    target CPU does not support.
+//! 3. We emit a FLO module that contains the code corresponding to the ingested
+//!    LLVM IR.
+//! 4. Externally to this compiler, this module—along with others that include
+//!    our polyfill implementations—are then linked together and undergo
+//!    whole-program consistency checks, optimization, and lowering to produce a
+//!    final binary.
 //!
 //! It should be noted that point 2 above is doing a lot of heavy lifting. As
 //! part of this translation we have to account for mismatches between calling
 //! conventions, stack and memory semantics, and perform translations of these
 //! things where they cannot directly be implemented using a polyfill.
+//!
+//! # Targeting `FlatLowered` instead of `Sierra`
+//!
+//! It might seem strange to target `FlatLowered` instead of something like
+//! [Sierra](https://docs.starknet.io/architecture-and-concepts/smart-contracts/cairo-and-sierra/#why_do_we_need_sierra)
+//! which is _intended_ as a target for compilation.
+//!
+//! While we definitely want the benefits of Sierra—particularly model checking
+//! for the underlying machine, and the gas monitoring—we do not want to perform
+//! all the necessary bookkeeping to make Sierra work on our own at the current
+//! time. By targeting `FlatLowered` instead, we gain the benefits of the
+//! _already existing_ [`sierragen`](https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-sierra-generator/src/lib.rs)
+//! functionality, which ingests `FlatLowered` and handles the required Sierra
+//! bookkeeping for us, while also being able to iterate and design faster.
+//!
+//! While this does give us less control---as we rely on the existing
+//! translation---the benefits of not having to manually perform this additional
+//! work far outweighs that downside.
+//!
+//! We fully expect to modify the process in the future to target `Sierra`
+//! directly, giving us more control as we need it.
 //!
 //! # Language Support
 //!
@@ -39,6 +93,13 @@
 //! require _some_ specialized work to allow those languages to properly call
 //! intrinsics that can interact with the chain and the larger Starknet
 //! ecosystem.
+//!
+//! # Tests
+//!
+//! While this crate includes unit tests for individual portions of its
+//! functionality, the majority of the tests for the compiler can be found in
+//! the `tests` integration test directory. These serve as useful examples for
+//! the external API for the compiler, and can be referenced in that context.
 
 #![warn(clippy::all, clippy::cargo, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)] // Allows for better API naming
@@ -47,15 +108,17 @@
 pub mod constant;
 pub mod context;
 pub mod llvm;
+pub mod obj_gen;
 pub mod pass;
 pub mod polyfill;
 
-use hieratika_errors::compile::{Error, Result};
+pub use hieratika_errors::compile::{Error, Result};
 use hieratika_flo::FlatLoweredObject;
 
 use crate::{
     context::SourceContext,
-    pass::{data::DynPassDataMap, PassManager, PassManagerReturnData},
+    obj_gen::ObjectGenerator,
+    pass::{analysis::module_map::BuildModuleMap, PassManager, PassManagerReturnData},
     polyfill::PolyfillMap,
 };
 
@@ -89,27 +152,6 @@ use crate::{
 /// the original LLVM IR—through use of translation and polyfills as needed—and
 /// to retain as much context information as possible so to ensure the
 /// possibility of a good user experience in the future.
-///
-/// # Targeting `FlatLowered` instead of `Sierra`
-///
-/// It might seem strange to target `FlatLowered` instead of something like
-/// [Sierra](https://docs.starknet.io/architecture-and-concepts/smart-contracts/cairo-and-sierra/#why_do_we_need_sierra)
-/// which is _intended_ as a target for compilation.
-///
-/// While we definitely want the benefits of Sierra—particularly model checking
-/// for the underlying machine, and the gas monitoring—we do not want to perform
-/// all the necessary bookkeeping to make Sierra work on our own at the current
-/// time. By targeting `FlatLowered` instead, we gain the benefits of the
-/// _already existing_ [`sierragen`](https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-sierra-generator/src/lib.rs)
-/// functionality, which ingests `FlatLowered` and handles the required Sierra
-/// bookkeeping for us, while also being able to iterate and design faster.
-///
-/// While this does give us less control—as we rely on the existing
-/// translation—the benefits of not having to manually perform this additional
-/// work far outweighs that downside.
-///
-/// We fully expect to modify the process in the future to target `Sierra`
-/// directly, giving us more control as we need it.
 pub struct Compiler {
     /// The source context, containing references to the LLVM module to be
     /// compiled.
@@ -123,6 +165,7 @@ pub struct Compiler {
     pub polyfill_map: PolyfillMap,
 }
 
+/// The basic operations required of the compiler.
 impl Compiler {
     /// Constructs a new compiler instance, wrapping the provided `context`
     /// describing the LLVM module to compile, the `passes` to run, and the
@@ -145,40 +188,24 @@ impl Compiler {
     ///
     /// - [`hieratika_errors::compile::Error`] if the compilation process fails
     ///   for any reason.
-    pub fn run(mut self) -> Result<CompilationResult> {
-        let PassManagerReturnData {
-            context: _context,
-            data: _data,
-        } = self.passes.run(self.context)?;
+    ///
+    /// # Panics
+    ///
+    /// - If the module mapping pass has not been run.
+    pub fn run(mut self) -> Result<FlatLoweredObject> {
+        // First we have to run all the passes and collect their data.
+        let PassManagerReturnData { context, data } = self.passes.run(self.context)?;
 
-        Err(Error::CompilationFailure(
-            "Compilation is not yet implemented".to_string(),
-        ))
-    }
-}
+        // After that, we can grab the module name out of the pass data.
+        let mod_name = data
+            .get::<BuildModuleMap>()
+            .expect("Module mapping pass has not been run, but it is required for code generation.")
+            .module_name
+            .clone();
 
-/// The result of compiling an LLVM IR module.
-#[derive(Debug)]
-pub struct CompilationResult {
-    /// The final state of the pass data after the compiler passes have been
-    /// executed.
-    pub pass_results: DynPassDataMap,
-
-    /// The `FLO` module that results from compilation.
-    pub result_module: FlatLoweredObject,
-}
-
-impl CompilationResult {
-    /// Constructs a new compilation result wrapping the final `FLO` module
-    /// and also containing the final output of any compiler passes.
-    #[must_use]
-    pub fn new(pass_results: DynPassDataMap) -> Self {
-        // TODO (#24) Actually compile to FLO.
-        let result_module = FlatLoweredObject::new("");
-        Self {
-            pass_results,
-            result_module,
-        }
+        // Then we can put our builder together and start the code generation process.
+        let builder = ObjectGenerator::new(&mod_name, data, context, self.polyfill_map)?;
+        builder.run()
     }
 }
 
@@ -256,23 +283,5 @@ impl CompilerBuilder {
             self.passes.unwrap_or_default(),
             self.polyfill_map.unwrap_or_default(),
         )
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::path::Path;
-
-    use crate::{context::SourceContext, CompilerBuilder};
-
-    #[test]
-    fn compiler_runs_successfully() -> anyhow::Result<()> {
-        let test_input = r"input/add.ll";
-        let ctx = SourceContext::create(Path::new(test_input))?;
-
-        let compiler = CompilerBuilder::new(ctx).build();
-        assert!(compiler.run().is_err());
-
-        Ok(())
     }
 }

--- a/crates/compiler/src/llvm/data_layout.rs
+++ b/crates/compiler/src/llvm/data_layout.rs
@@ -269,6 +269,62 @@ impl DataLayout {
         specs.sort();
         specs
     }
+
+    /// Gets the integer layout corresponding to integers of the provided
+    /// `size`, or returns [`None`] if no such layout is available.
+    #[must_use]
+    pub fn int_spec_of(&self, size: usize) -> Option<&IntegerLayout> {
+        self.integer_layouts.iter().find(|int_spec| int_spec.size == size)
+    }
+
+    /// Gets the integer layout corresponding to integers of the provided
+    /// `size`.
+    ///
+    /// # Panics
+    ///
+    /// If no layout exists in the data layout for integers of the provided
+    /// `size`.
+    #[must_use]
+    pub fn expect_int_spec_of(&self, size: usize) -> &IntegerLayout {
+        self.int_spec_of(size)
+            .unwrap_or_else(|| panic!("No layout found for integer of size {size}"))
+    }
+
+    /// Gets the floating-point layout corresponding to floating-point numbers
+    /// of the provided `size`, or returns [`None`] if no such layout is
+    /// available.
+    #[must_use]
+    pub fn float_spec_of(&self, size: usize) -> Option<&FloatLayout> {
+        self.float_layouts.iter().find(|float_spec| float_spec.size == size)
+    }
+
+    /// Gets the floating-point layout corresponding to floating-point numbers
+    /// of the provided `size`.
+    ///
+    /// # Panics
+    ///
+    /// If no layout exists in the data layout for floating-point of the
+    /// provided `size`.
+    #[must_use]
+    pub fn expect_float_spec_of(&self, size: usize) -> &FloatLayout {
+        self.float_spec_of(size)
+            .unwrap_or_else(|| panic!("No layout found for float of size {size}"))
+    }
+
+    /// Gets the pointer layout specification for the default address space.
+    ///
+    /// # Panics
+    ///
+    /// If the data layout somehow does not contain a pointer layout for the
+    /// default address space zero. This is required to exist, so panic here
+    /// indicates a programmer error.
+    #[must_use]
+    pub fn default_pointer_layout(&self) -> &PointerLayout {
+        self.pointer_layouts
+            .iter()
+            .find(|ptr_layout| ptr_layout.address_space == 0)
+            .expect("No pointer layout existed for the default address space")
+    }
 }
 
 impl Default for DataLayout {

--- a/crates/compiler/src/llvm/special_intrinsics.rs
+++ b/crates/compiler/src/llvm/special_intrinsics.rs
@@ -11,7 +11,10 @@ use std::collections::HashMap;
 use inkwell::{module::Linkage, GlobalVisibility};
 
 use crate::{
-    llvm::{typesystem::LLVMType, TopLevelEntryKind},
+    llvm::{
+        typesystem::{LLVMFunction, LLVMType},
+        TopLevelEntryKind,
+    },
     pass::analysis::module_map::FunctionInfo,
 };
 
@@ -31,35 +34,37 @@ impl SpecialIntrinsics {
         intrinsics.insert(
             "llvm.dbg.declare".to_string(),
             FunctionInfo {
-                kind:       TopLevelEntryKind::Declaration,
-                intrinsic:  true,
-                typ:        LLVMType::make_function(
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
                     LLVMType::void,
                     &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata],
                 ),
-                linkage:    Linkage::External,
-                visibility: GlobalVisibility::Default,
+                param_names: vec![None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
             },
         );
         intrinsics.insert(
             "llvm.dbg.value".to_string(),
             FunctionInfo {
-                kind:       TopLevelEntryKind::Declaration,
-                intrinsic:  true,
-                typ:        LLVMType::make_function(
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
                     LLVMType::void,
                     &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata],
                 ),
-                linkage:    Linkage::External,
-                visibility: GlobalVisibility::Default,
+                param_names: vec![None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
             },
         );
         intrinsics.insert(
             "llvm.dbg.assign".to_string(),
             FunctionInfo {
-                kind:       TopLevelEntryKind::Declaration,
-                intrinsic:  true,
-                typ:        LLVMType::make_function(
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
                     LLVMType::void,
                     &[
                         LLVMType::Metadata,
@@ -69,8 +74,9 @@ impl SpecialIntrinsics {
                         LLVMType::Metadata,
                     ],
                 ),
-                linkage:    Linkage::External,
-                visibility: GlobalVisibility::Default,
+                param_names: vec![None, None, None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
             },
         );
 

--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -18,7 +18,7 @@ use inkwell::types::{
 };
 use itertools::Itertools;
 
-use crate::constant::BYTE_SIZE;
+use crate::{constant::BYTE_SIZE, llvm::data_layout::DataLayout};
 
 /// A representation of the LLVM [types](https://llvm.org/docs/LangRef.html#type-system)
 /// for use within the compiler.
@@ -88,13 +88,7 @@ pub enum LLVMType {
     /// An [array](https://llvm.org/docs/LangRef.html#array-type) is a
     /// sequential arrangement of a number of elements of the given type
     /// linearly in memory.
-    Array {
-        /// The number of elements in the array type.
-        count: usize,
-
-        /// The type of elements in the array type.
-        typ: Box<LLVMType>,
-    },
+    Array(LLVMArray),
 
     /// A [structure](https://llvm.org/docs/LangRef.html#structure-type)
     /// represents a number of elements together in memory.
@@ -102,32 +96,11 @@ pub enum LLVMType {
     /// Note that struct elements do not have names, and can only be accessed by
     /// index. This makes LLVM struct types far more akin to what we call a
     /// Tuple in most languages.
-    Structure {
-        /// If the structure is packed, it has one-byte alignment with no
-        /// padding between elements.
-        ///
-        /// If it is not packed, then the padding and alignment of struct
-        /// elements is given by the module's data-layout string.
-        packed: bool,
-
-        /// The element types in the structure type.
-        ///
-        /// The order is semantically meaninful here.
-        elements: Vec<LLVMType>,
-    },
+    Structure(LLVMStruct),
 
     /// A [function](https://llvm.org/docs/LangRef.html#function-type) is akin
     /// to a function signature.
-    Function {
-        /// The type returned from the function.
-        return_type: Box<LLVMType>,
-
-        /// The types of the parameters to the function.
-        ///
-        /// Note that these are never named, and are purely matched
-        /// positionally.
-        parameter_types: Vec<LLVMType>,
-    },
+    Function(LLVMFunction),
 
     /// Embedded [metadata](https://llvm.org/docs/LangRef.html#metadata-type)
     /// used as a value has this type.
@@ -141,30 +114,21 @@ impl LLVMType {
     /// elements of type `elem_type`.
     #[must_use]
     pub fn make_array(elem_count: usize, elem_type: LLVMType) -> Self {
-        Self::Array {
-            count: elem_count,
-            typ:   Box::new(elem_type),
-        }
+        Self::Array(LLVMArray::new(elem_count, elem_type))
     }
 
     /// Creates a struct type from the provided `elem_types` and whether it is
     /// `packed`.
     #[must_use]
     pub fn make_struct(packed: bool, elem_types: &[LLVMType]) -> Self {
-        Self::Structure {
-            packed,
-            elements: Vec::from(elem_types),
-        }
+        Self::Structure(LLVMStruct::new(packed, elem_types))
     }
 
     /// Creates a function type from the provided `return_type` and
     /// `param_types`.
     #[must_use]
     pub fn make_function(return_type: LLVMType, param_types: &[LLVMType]) -> Self {
-        Self::Function {
-            return_type:     Box::new(return_type),
-            parameter_types: Vec::from(param_types),
-        }
+        Self::Function(LLVMFunction::new(return_type, param_types))
     }
 }
 
@@ -222,6 +186,75 @@ impl LLVMType {
     pub fn is_float(&self) -> bool {
         matches!(self, Self::half | Self::float | Self::double)
     }
+
+    /// Returns `self` as a function type if it exists, and otherwise returns
+    /// [`None`].
+    #[must_use]
+    pub fn as_function(&self) -> Option<&LLVMFunction> {
+        match self {
+            Self::Function(func) => Some(func),
+            _ => None,
+        }
+    }
+
+    /// Returns `self` as a function type if possible.
+    ///
+    /// # Panics
+    ///
+    /// If `self` is not a function type.
+    #[must_use]
+    pub fn expect_function(&self) -> &LLVMFunction {
+        self.as_function().expect("`self` value was not Self::Function")
+    }
+
+    /// Gets the size of `self` in bits under the provided data layout.
+    #[must_use]
+    pub fn size_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        #[allow(clippy::match_same_arms)] // The similarity is incidental
+        match self {
+            LLVMType::bool => layout.expect_int_spec_of(1).size,
+            LLVMType::i8 => layout.expect_int_spec_of(8).size,
+            LLVMType::i16 => layout.expect_int_spec_of(16).size,
+            LLVMType::i32 => layout.expect_int_spec_of(32).size,
+            LLVMType::i64 => layout.expect_int_spec_of(64).size,
+            LLVMType::i128 => layout.expect_int_spec_of(128).size,
+            LLVMType::half => layout.expect_float_spec_of(16).size,
+            LLVMType::float => layout.expect_float_spec_of(32).size,
+            LLVMType::double => layout.expect_float_spec_of(64).size,
+            LLVMType::ptr => layout.default_pointer_layout().size,
+            LLVMType::void => 0,
+            LLVMType::Array(array_ty) => array_ty.size_of(layout),
+            LLVMType::Structure(struct_ty) => struct_ty.size_of(layout),
+            LLVMType::Function(func_ty) => func_ty.size_of(layout),
+            LLVMType::Metadata => 0,
+        }
+    }
+
+    /// Gets the ABI alignment of `self` in bits under the provided data
+    /// layout.
+    #[must_use]
+    pub fn align_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        #[allow(clippy::match_same_arms)] // The similarity is incidental
+        match self {
+            LLVMType::bool => layout.expect_int_spec_of(1).abi_alignment,
+            LLVMType::i8 => layout.expect_int_spec_of(8).abi_alignment,
+            LLVMType::i16 => layout.expect_int_spec_of(16).abi_alignment,
+            LLVMType::i32 => layout.expect_int_spec_of(32).abi_alignment,
+            LLVMType::i64 => layout.expect_int_spec_of(64).abi_alignment,
+            LLVMType::i128 => layout.expect_int_spec_of(128).abi_alignment,
+            LLVMType::half => layout.expect_float_spec_of(16).abi_alignment,
+            LLVMType::float => layout.expect_float_spec_of(32).abi_alignment,
+            LLVMType::double => layout.expect_float_spec_of(64).abi_alignment,
+            LLVMType::ptr => layout.default_pointer_layout().abi_alignment,
+            LLVMType::void => 0,
+            LLVMType::Array(array_ty) => array_ty.align_of(layout),
+            LLVMType::Structure(struct_ty) => struct_ty.align_of(layout),
+            LLVMType::Function(func_ty) => func_ty.align_of(layout),
+            LLVMType::Metadata => 0,
+        }
+    }
 }
 
 /// This attempts to match the LLVM representations for these types where it is
@@ -244,11 +277,11 @@ impl Display for LLVMType {
             LLVMType::ptr => "ptr".to_string(),
             LLVMType::void => "void".to_string(),
             LLVMType::Metadata => "metadata".to_string(),
-            LLVMType::Array { count, typ: ty } => {
-                let ty_str = ty.to_string();
+            LLVMType::Array(LLVMArray { count, typ }) => {
+                let ty_str = typ.to_string();
                 format!("[{ty_str}; {count}]")
             }
-            LLVMType::Structure { packed, elements } => {
+            LLVMType::Structure(LLVMStruct { packed, elements }) => {
                 let elem_strs = elements.iter().map(std::string::ToString::to_string).join(", ");
                 if *packed {
                     format!("<{{ {elem_strs} }}>")
@@ -256,10 +289,10 @@ impl Display for LLVMType {
                     format!("{{ {elem_strs} }}")
                 }
             }
-            LLVMType::Function {
+            LLVMType::Function(LLVMFunction {
                 return_type,
                 parameter_types,
-            } => {
+            }) => {
                 let params_string = parameter_types
                     .iter()
                     .map(std::string::ToString::to_string)
@@ -338,9 +371,7 @@ impl<'ctx> TryFrom<&ArrayType<'ctx>> for LLVMType {
     type Error = compile::Error;
 
     fn try_from(value: &ArrayType<'ctx>) -> Result<Self, Self::Error> {
-        let length = value.len() as usize;
-        let elem_type = Self::try_from(value.get_element_type())?;
-        Ok(Self::make_array(length, elem_type))
+        Ok(Self::Array(LLVMArray::try_from(value)?))
     }
 }
 
@@ -446,13 +477,7 @@ impl<'ctx> TryFrom<&StructType<'ctx>> for LLVMType {
     type Error = compile::Error;
 
     fn try_from(value: &StructType<'ctx>) -> Result<Self, Self::Error> {
-        let field_types: Vec<Self> = value
-            .get_field_types()
-            .iter()
-            .map(Self::try_from)
-            .collect::<Result<Vec<Self>, Error>>()?;
-        let packed = value.is_packed();
-        Ok(Self::make_struct(packed, &field_types))
+        Ok(Self::Structure(LLVMStruct::try_from(value)?))
     }
 }
 
@@ -498,14 +523,7 @@ impl<'ctx> TryFrom<&FunctionType<'ctx>> for LLVMType {
     type Error = compile::Error;
 
     fn try_from(value: &FunctionType<'ctx>) -> Result<Self, Self::Error> {
-        let return_type = value.get_return_type().map_or(Ok(LLVMType::void), Self::try_from)?;
-        let param_types = value
-            .get_param_types()
-            .iter()
-            .map(Self::try_from)
-            .collect::<Result<Vec<Self>, Error>>()?;
-
-        Ok(Self::make_function(return_type, &param_types))
+        Ok(Self::Function(LLVMFunction::try_from(value)?))
     }
 }
 
@@ -530,5 +548,275 @@ impl<'ctx> TryFrom<&VoidType<'ctx>> for LLVMType {
 
     fn try_from(_: &VoidType<'ctx>) -> Result<Self, Self::Error> {
         Ok(Self::void)
+    }
+}
+
+/// An [array](https://llvm.org/docs/LangRef.html#array-type) is a sequential
+/// arrangement of a number of elements of the given type linearly in memory.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct LLVMArray {
+    /// The number of elements in the array type.
+    pub count: usize,
+
+    /// The type of elements in the array type.
+    pub typ: Box<LLVMType>,
+}
+
+impl LLVMArray {
+    /// Creates a new LLVM array type from the provided `count` and `typ`.
+    #[must_use]
+    pub fn new(count: usize, typ: LLVMType) -> Self {
+        let typ = Box::new(typ);
+        Self { count, typ }
+    }
+
+    /// Gets the size of `self` in bits under the provided data layout.
+    #[must_use]
+    pub fn size_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        let size_of_elem = self.typ.size_of(layout);
+        let align_of_elem = self.typ.align_of(layout);
+        let total_size_per_elem = if size_of_elem > align_of_elem {
+            align_of_elem * (1 + align_of_elem / size_of_elem)
+        } else {
+            align_of_elem
+        };
+
+        total_size_per_elem * self.count
+    }
+
+    /// Gets the ABI alignment of `self` in bits under the provided data layout.
+    #[must_use]
+    pub fn align_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        layout.aggregate_layout.abi_alignment
+    }
+}
+
+impl From<LLVMArray> for LLVMType {
+    fn from(value: LLVMArray) -> Self {
+        LLVMType::Array(value)
+    }
+}
+
+impl TryFrom<LLVMType> for LLVMArray {
+    type Error = compile::Error;
+
+    fn try_from(value: LLVMType) -> Result<Self, Self::Error> {
+        match value {
+            LLVMType::Array(array) => Ok(array),
+            _ => Err(Error::invalid_type_conversion(
+                "Cannot convert non-array LLVMType to LLVMArray",
+            )),
+        }
+    }
+}
+
+impl<'ctx> TryFrom<ArrayType<'ctx>> for LLVMArray {
+    type Error = compile::Error;
+
+    fn try_from(value: ArrayType<'ctx>) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl<'ctx> TryFrom<&ArrayType<'ctx>> for LLVMArray {
+    type Error = compile::Error;
+
+    fn try_from(value: &ArrayType<'ctx>) -> Result<Self, Self::Error> {
+        let length = value.len() as usize;
+        let elem_type = LLVMType::try_from(value.get_element_type())?;
+        Ok(Self::new(length, elem_type))
+    }
+}
+
+/// A [structure](https://llvm.org/docs/LangRef.html#structure-type)
+/// represents a number of elements together in memory.
+///
+/// Note that struct elements do not have names, and can only be accessed by
+/// index. This makes LLVM struct types far more akin to what we call a
+/// Tuple in most languages.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct LLVMStruct {
+    /// If the structure is packed, it has one-byte alignment with no
+    /// padding between elements.
+    ///
+    /// If it is not packed, then the padding and alignment of struct
+    /// elements is given by the module's data-layout string.
+    pub packed: bool,
+
+    /// The element types in the structure type.
+    ///
+    /// The order is semantically meaningful here.
+    pub elements: Vec<LLVMType>,
+}
+
+impl LLVMStruct {
+    /// Creates a new LLVM struct from the provided `packed` specification and
+    /// `elements` types.
+    #[must_use]
+    pub fn new(packed: bool, elements: &[LLVMType]) -> Self {
+        let elements = elements.to_vec();
+
+        Self { packed, elements }
+    }
+
+    /// Gets the size of `self` in bits under the provided data layout.
+    #[must_use]
+    pub fn size_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        self.elements
+            .iter()
+            .map(|element| {
+                if self.packed {
+                    element.size_of(layout)
+                } else {
+                    let size_of_element = element.size_of(layout);
+                    let align_of_element = element.size_of(layout);
+                    if size_of_element > align_of_element {
+                        align_of_element * (1 + align_of_element / size_of_element)
+                    } else {
+                        align_of_element
+                    }
+                }
+            })
+            .sum()
+    }
+
+    /// Gets the ABI alignment of `self` in bits under the provided data layout.
+    #[must_use]
+    pub fn align_of(&self, layout: &DataLayout) -> usize {
+        // TODO (#29) Make this comply with the design for the memory model.
+        layout.aggregate_layout.abi_alignment
+    }
+}
+
+impl From<LLVMStruct> for LLVMType {
+    fn from(value: LLVMStruct) -> Self {
+        LLVMType::Structure(value)
+    }
+}
+
+impl TryFrom<LLVMType> for LLVMStruct {
+    type Error = compile::Error;
+
+    fn try_from(value: LLVMType) -> Result<Self, Self::Error> {
+        match value {
+            LLVMType::Structure(structure) => Ok(structure),
+            _ => Err(Error::invalid_type_conversion(
+                "Cannot convert non-struct LLVMType to LLVMStruct",
+            )),
+        }
+    }
+}
+
+impl<'ctx> TryFrom<StructType<'ctx>> for LLVMStruct {
+    type Error = compile::Error;
+
+    fn try_from(value: StructType<'ctx>) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl<'ctx> TryFrom<&StructType<'ctx>> for LLVMStruct {
+    type Error = compile::Error;
+
+    fn try_from(value: &StructType<'ctx>) -> Result<Self, Self::Error> {
+        let field_types = value
+            .get_field_types()
+            .iter()
+            .map(LLVMType::try_from)
+            .collect::<Result<Vec<LLVMType>, Error>>()?;
+        let packed = value.is_packed();
+
+        Ok(Self::new(packed, &field_types))
+    }
+}
+
+/// A [function](https://llvm.org/docs/LangRef.html#function-type) is akin
+/// to a function signature.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct LLVMFunction {
+    /// The type returned from the function.
+    pub return_type: Box<LLVMType>,
+
+    /// The types of the parameters to the function.
+    ///
+    /// Note that these are never named, and are purely matched
+    /// positionally.
+    pub parameter_types: Vec<LLVMType>,
+}
+
+impl LLVMFunction {
+    /// Constructs a new LLVM function type from the provided `return_type` and
+    /// `parameter_types`.
+    #[must_use]
+    pub fn new(return_type: LLVMType, parameter_types: &[LLVMType]) -> Self {
+        let return_type = Box::new(return_type);
+        let parameter_types = parameter_types.to_vec();
+        Self {
+            return_type,
+            parameter_types,
+        }
+    }
+
+    /// Gets the size of `self` in bits under the provided data layout.
+    ///
+    /// This is given by the size of the function's return type.
+    #[must_use]
+    pub fn size_of(&self, layout: &DataLayout) -> usize {
+        self.return_type.size_of(layout)
+    }
+
+    /// Gets the ABI alignment of `self` in bits under the provided data layout.
+    ///
+    /// This is given by the ABI alignment of the function's return type.
+    #[must_use]
+    pub fn align_of(&self, layout: &DataLayout) -> usize {
+        self.return_type.align_of(layout)
+    }
+}
+
+impl From<LLVMFunction> for LLVMType {
+    fn from(value: LLVMFunction) -> Self {
+        Self::Function(value)
+    }
+}
+
+impl TryFrom<LLVMType> for LLVMFunction {
+    type Error = compile::Error;
+
+    fn try_from(value: LLVMType) -> Result<Self, Self::Error> {
+        match value {
+            LLVMType::Function(function) => Ok(function),
+            _ => Err(Error::invalid_type_conversion(
+                "Cannot convert non-function LLVMType to LLVMFunction",
+            )),
+        }
+    }
+}
+
+impl<'ctx> TryFrom<FunctionType<'ctx>> for LLVMFunction {
+    type Error = compile::Error;
+
+    fn try_from(value: FunctionType<'ctx>) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl<'ctx> TryFrom<&FunctionType<'ctx>> for LLVMFunction {
+    type Error = compile::Error;
+
+    fn try_from(value: &FunctionType<'ctx>) -> Result<Self, Self::Error> {
+        let return_type = value
+            .get_return_type()
+            .map_or(Ok(LLVMType::void), LLVMType::try_from)?;
+        let param_types = value
+            .get_param_types()
+            .iter()
+            .map(LLVMType::try_from)
+            .collect::<Result<Vec<LLVMType>, Error>>()?;
+
+        Ok(Self::new(return_type, &param_types))
     }
 }

--- a/crates/compiler/src/obj_gen/data.rs
+++ b/crates/compiler/src/obj_gen/data.rs
@@ -1,0 +1,333 @@
+//! This module contains the output structures for the code generation process.
+
+use std::collections::HashMap;
+
+use bimap::BiHashMap;
+use hieratika_errors::compile::{Error, Result};
+use hieratika_flo::{
+    types::{ArrayType, BlockId, PoisonType, StructType, Type, VariableId, VariableLinkage},
+    FlatLoweredObject,
+};
+use inkwell::module::Linkage;
+
+use crate::llvm::typesystem::{LLVMArray, LLVMFunction, LLVMStruct, LLVMType};
+
+/// A mapping from the names of locally-defined functions to their identifiers.
+pub type ModuleFunctions = BiHashMap<String, BlockId>;
+
+/// A mapping from the names of locally-defined globals to their identifiers.
+pub type ModuleGlobals = BiHashMap<String, VariableId>;
+
+/// The data store for the in-progress work of the object generator.
+///
+/// This is intended to be handed as a mutable reference through each of the
+/// steps of the code generation process, and modified by each step.
+#[derive(Debug)]
+pub struct ObjectContext {
+    /// The underlying FLO that is being generated as part of the code
+    /// generation process.
+    ///
+    /// Please note that at any point this object may be in an **invalid
+    /// state**, as this is allowed to aid compilation. The consumer of the API
+    /// is responsible for ensuring that the FLO is in a coherent or valid state
+    /// (namely that it does not contain any poisoned values and that it
+    /// represents the correct program structure) _before_ finalizing its
+    /// generation.
+    pub flo: FlatLoweredObject,
+
+    /// A mapping from the names of locally-defined functions to their
+    /// identifiers.
+    ///
+    /// Behavior may be inconsistent if the identifier was not allocated in the
+    /// `flo` object contained in `Self`.
+    pub module_functions: ModuleFunctions,
+
+    /// A mapping from the names of locally-defined globals to their
+    /// identifiers.
+    ///
+    /// Behavior may be inconsistent if the identifier was not allocated in the
+    /// `flo` object contained in `Self`.
+    pub module_globals: ModuleGlobals,
+}
+
+/// Functionality that requires access to the FLO context directly.
+impl ObjectContext {
+    /// Constructs a new code generator data store for the module with the
+    /// provided name.
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        let flo = FlatLoweredObject::new(name);
+        let module_functions = ModuleFunctions::default();
+        let module_globals = ModuleGlobals::default();
+
+        Self {
+            flo,
+            module_functions,
+            module_globals,
+        }
+    }
+
+    /// Gets a copy of the top-level functions defined in this module.
+    ///
+    /// Please note that any updates made to `self.module_functions` will not be
+    /// reflected in this copy.
+    #[must_use]
+    pub fn copy_module_functions(&self) -> ModuleFunctions {
+        self.module_functions.clone()
+    }
+
+    /// Gets a copy of the top-level globals defined in this module.
+    ///
+    /// Please note that any updates made to `self.module_globals` will not be
+    /// reflected in this copy.
+    #[must_use]
+    pub fn copy_module_globals(&self) -> ModuleGlobals {
+        self.module_globals.clone()
+    }
+}
+
+/// Useful functionality that does not require access to the FLO context
+/// directly, but nevertheless deals with the generation of FLO.
+impl ObjectContext {
+    /// Generates the correct FLO linkage from the provided LLVM `linkage`.
+    #[must_use]
+    pub fn linkage_of(linkage: &Linkage, name: &str) -> VariableLinkage {
+        match linkage {
+            Linkage::Appending
+            | Linkage::AvailableExternally
+            | Linkage::Common
+            | Linkage::DLLExport
+            | Linkage::DLLImport
+            | Linkage::External
+            | Linkage::ExternalWeak
+            | Linkage::LinkOnceAny
+            | Linkage::LinkOnceODRAutoHide
+            | Linkage::LinkOnceODR
+            | Linkage::WeakAny
+            | Linkage::WeakODR => VariableLinkage::External(name.to_string()),
+            Linkage::Ghost
+            | Linkage::Internal
+            | Linkage::LinkerPrivate
+            | Linkage::LinkerPrivateWeak
+            | Linkage::Private => VariableLinkage::Local,
+        }
+    }
+
+    /// Generates the FLO type system representation of the provided `typ`
+    /// wherever possible.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidTypeConversion`] if the provided `typ` cannot be
+    ///   represented inside the FLO type system.
+    pub fn flo_type_of(typ: &LLVMType) -> Result<Type> {
+        let array_to_flo = |typ: &LLVMArray| -> Result<Type> {
+            let member_type = Box::new(Self::flo_type_of(&typ.typ)?);
+            let length = typ.count;
+            let diagnostics = Vec::new();
+            let location = None;
+            let poison = PoisonType::None;
+            let array_type = ArrayType {
+                member_type,
+                length,
+                diagnostics,
+                location,
+                poison,
+            };
+            Ok(Type::Array(array_type))
+        };
+
+        let struct_to_flo = |typ: &LLVMStruct| -> Result<Type> {
+            let members = typ
+                .elements
+                .iter()
+                .map(Self::flo_type_of)
+                .collect::<Result<Vec<_>>>()?;
+            let diagnostics = Vec::new();
+            let location = None;
+            let poison = PoisonType::None;
+            let struct_type = StructType {
+                members,
+                diagnostics,
+                location,
+                poison,
+            };
+            Ok(Type::Struct(struct_type))
+        };
+
+        let result_ty: Type = match typ {
+            LLVMType::bool => Type::Bool,
+            LLVMType::i8 => Type::Signed8,
+            LLVMType::i16 => Type::Signed16,
+            LLVMType::i32 => Type::Signed32,
+            LLVMType::i64 => Type::Signed64,
+            LLVMType::i128 => Type::Signed128,
+            LLVMType::half => Err(Error::invalid_type_conversion(
+                "We do not currently support half-precision floats",
+            ))?,
+            LLVMType::float => Type::Float,
+            LLVMType::double => Type::Double,
+            LLVMType::ptr => Type::Pointer,
+            LLVMType::void => Type::Void,
+            LLVMType::Array(array) => array_to_flo(array)?,
+            LLVMType::Structure(structure) => struct_to_flo(structure)?,
+            LLVMType::Function(_) => Err(Error::invalid_type_conversion(
+                "FLO does not support a first-class function type",
+            ))?,
+            LLVMType::Metadata => Err(Error::invalid_type_conversion(
+                "We do not currently support the metadata type",
+            ))?,
+        };
+
+        Ok(result_ty)
+    }
+}
+
+impl From<ObjectContext> for FlatLoweredObject {
+    fn from(value: ObjectContext) -> Self {
+        value.flo
+    }
+}
+
+/// Stores the information needed to perform correct code generation for a
+/// function.
+///
+/// Note that instances of this type **must not** be reused across function
+/// generation steps.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FunctionContext {
+    /// The type signature of the function.
+    func_type: LLVMFunction,
+
+    /// The basic blocks that occur in the function as a bidirectional mapping
+    /// from names to block identifiers.
+    pub blocks: BiHashMap<String, BlockId>,
+
+    /// The global variables accessible to the function as a bidirectional
+    /// mapping from names to identifiers.
+    globals: ModuleGlobals,
+
+    /// The local variables that occur in the function as a bidirectional
+    /// mapping from names to identifiers.
+    locals: BiHashMap<String, VariableId>,
+
+    /// A mapping from variable identifiers to variable types, used for
+    /// consistency checking during compilation.
+    var_types: HashMap<VariableId, Type>,
+
+    /// A mapping from the names of functions defined in the same module as the
+    /// function described by `self` to their identifiers.
+    ///
+    /// Behavior may be inconsistent if the identifier was not allocated in the
+    /// same `flo` object as the function that `self` describes.
+    module_functions: ModuleFunctions,
+}
+
+impl FunctionContext {
+    /// Creates a new, empty instance of the function context.
+    #[must_use]
+    pub fn new(
+        func_type: LLVMFunction,
+        module_functions: ModuleFunctions,
+        globals: ModuleGlobals,
+    ) -> Self {
+        let blocks = BiHashMap::new();
+        let locals = BiHashMap::new();
+        let var_types = HashMap::new();
+
+        Self {
+            func_type,
+            blocks,
+            globals,
+            locals,
+            var_types,
+            module_functions,
+        }
+    }
+
+    /// Gets the type of the function represented by the context.
+    #[must_use]
+    pub fn typ(&self) -> LLVMFunction {
+        self.func_type.clone()
+    }
+
+    /// Gets a reference to the mapping between names and identifiers for global
+    /// variables.
+    #[must_use]
+    pub fn globals(&self) -> &BiHashMap<String, VariableId> {
+        &self.globals
+    }
+
+    /// Gets a reference to the mapping between names and identifiers for local
+    /// variables.
+    #[must_use]
+    pub fn locals(&self) -> &BiHashMap<String, VariableId> {
+        &self.locals
+    }
+
+    /// Looks up the variable with the given `name` in the function context,
+    /// returning its identifier if it exists, or [`None`] if it does not.
+    #[must_use]
+    pub fn lookup_variable(&self, name: &str) -> Option<VariableId> {
+        // We look up in locals and then in globals. This order is very intentional, as
+        // it implicitly supports shadowing even though this should not occur in LLVM
+        // IR.
+        self.locals
+            .get_by_left(name)
+            .copied()
+            .or(self.globals.get_by_left(name).copied())
+    }
+
+    /// Gets a reference to the mapping between identifiers and types for local
+    /// variables.
+    #[must_use]
+    pub fn var_types(&self) -> &HashMap<VariableId, Type> {
+        &self.var_types
+    }
+
+    /// Register the variable with the provided `id`, `name`, and `typ` into the
+    /// function context.
+    pub fn register_local(&mut self, id: VariableId, name: &str, typ: Type) {
+        self.locals.insert(name.to_string(), id);
+        self.var_types.insert(id, typ);
+    }
+
+    /// Gets a reference to a mapping between the names and identifiers of the
+    /// functions defined in the same module as the function described by
+    /// `self`.
+    #[must_use]
+    pub fn module_functions(&self) -> &ModuleFunctions {
+        &self.module_functions
+    }
+}
+
+/// A supply of fresh names, only one of which should exist per module.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FreshNameSupply {
+    name_counter: usize,
+}
+
+impl Default for FreshNameSupply {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FreshNameSupply {
+    /// Creates a new fresh name supply that has allocated no names.
+    #[must_use]
+    pub fn new() -> Self {
+        // We start at 1 to avoid having names that are the default value for the
+        // underlying type, and hence try and avoid bugs.
+        let name_counter = 1;
+
+        Self { name_counter }
+    }
+
+    /// Allocates a unique name from the name supply.
+    pub fn allocate(&mut self) -> String {
+        let name_num = self.name_counter;
+        self.name_counter += 1;
+        name_num.to_string()
+    }
+}

--- a/crates/compiler/src/obj_gen/mod.rs
+++ b/crates/compiler/src/obj_gen/mod.rs
@@ -1,0 +1,1158 @@
+//! The infrastructure for building `FLO` objects to support the additional
+//! non-generic functionality not embedded in [`FlatLoweredObject`] itself.
+
+pub mod data;
+pub mod util;
+
+use std::cell::RefCell;
+
+use hieratika_errors::compile::{Error, Result};
+use hieratika_flo::{
+    builders::BlockBuilder,
+    types::{
+        BlockExit,
+        BlockId,
+        BlockRef,
+        ConstantValue,
+        PoisonType,
+        Signature,
+        Type,
+        Variable,
+        VariableId,
+        VariableLinkage,
+    },
+    FlatLoweredObject,
+};
+use inkwell::{
+    basic_block::BasicBlock,
+    module::Module,
+    values::{FunctionValue, GlobalValue, InstructionOpcode, InstructionValue},
+    GlobalVisibility,
+};
+use itertools::Itertools;
+
+use crate::{
+    context::SourceContext,
+    llvm::{special_intrinsics::SpecialIntrinsics, typesystem::LLVMType},
+    obj_gen::{
+        data::{FreshNameSupply, FunctionContext, ObjectContext},
+        util::{
+            expect_func_name_from_bv,
+            expect_int_from_bv,
+            extract_block_operand,
+            extract_value_operand,
+            extract_value_operands,
+            get_indices,
+            is_non_terminator_instruction,
+            is_terminator_instruction,
+            name_from_bv,
+            name_type_pairs_from_value_operands,
+            should_define_func,
+        },
+    },
+    pass::{
+        analysis::module_map::{BuildModuleMap, FunctionInfo, GlobalInfo},
+        data::DynPassDataMap,
+    },
+    polyfill::PolyfillMap,
+};
+
+/// Handles the minutiae of building a [`FlatLoweredObject`], as well as
+/// tracking all the additional metadata required to properly construct that
+/// object.
+///
+/// Please note that ensuring the validity of the object is up to the
+/// **consumer** of this API. It is intended to be allowed to be left in invalid
+/// states to aid construction, but will be checked for validity at completion
+/// of the construction process. See the documentation for [`FlatLoweredObject`]
+/// for more detail.
+#[derive(Debug)]
+pub struct ObjectGenerator {
+    /// The name of the module being compiled.
+    name: String,
+
+    /// The result data from all the analysis passes that have been run at the
+    /// stage of building.
+    ///
+    /// It is intended to never be mutated during the building process.
+    pass_data: DynPassDataMap,
+
+    /// The source LLVM context that serves as the source of data from which
+    /// compilation occurs.
+    source_context: SourceContext,
+
+    /// The mapping from LLVM names to the corresponding polyfills.
+    polyfills: PolyfillMap,
+
+    /// A supply of unique names for the module.
+    ///
+    /// This is dynamically borrow-checked, and should not be accessed directly.
+    /// See [`Self::allocate_name`] instead.
+    name_supply: RefCell<FreshNameSupply>,
+}
+
+/// Basic operations for construction and accessing fields.
+impl ObjectGenerator {
+    /// Constructs a new code generator instance for the module with name
+    /// `module_name`, as well as the provided `pass_data` and `source_context`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::MissingModuleName`] if the provided `module_name` is empty as
+    ///   it should already have been populated even if otherwise empty by the
+    ///   [`BuildModuleMap`] pass.
+    pub fn new(
+        module_name: &str,
+        pass_data: DynPassDataMap,
+        source_context: SourceContext,
+        polyfills: PolyfillMap,
+    ) -> Result<Self> {
+        let name = if module_name.is_empty() {
+            Err(Error::MissingModuleName)?
+        } else {
+            module_name.to_string()
+        };
+
+        let name_supply = RefCell::new(FreshNameSupply::new());
+
+        Ok(Self {
+            name,
+            pass_data,
+            source_context,
+            polyfills,
+            name_supply,
+        })
+    }
+
+    /// Gets the name of the module being built.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets an immutable reference to the pass data that the builder has been
+    /// provided with.
+    pub fn pass_data(&self) -> &DynPassDataMap {
+        &self.pass_data
+    }
+
+    /// Gets an immutable reference to the LLVM context serving as the source of
+    /// inputs to the code generation process.
+    pub fn context(&self) -> &SourceContext {
+        &self.source_context
+    }
+
+    /// Allocates a new unique name.
+    #[must_use]
+    pub fn allocate_name(&self) -> String {
+        self.name_supply.borrow_mut().allocate()
+    }
+}
+
+/// These functions perform code-generation for top-level entries in an LLVM
+/// module.
+impl ObjectGenerator {
+    /// Executes the code generation process on a freshly created
+    /// [`FlatLoweredObject`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the code generation process fails for any reason.
+    pub fn run(&self) -> Result<FlatLoweredObject> {
+        let mut cg_data = ObjectContext::new(&self.name);
+
+        self.context()
+            .analyze_module(|m| self.generate_module(m, &mut cg_data))?;
+
+        Ok(cg_data.into())
+    }
+
+    /// Performs the code generation process for the entire `module` currently
+    /// being processed, generating equivalent object code into the provided
+    /// `data` output.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the module cannot be generated for any reason.
+    ///
+    /// # Panics
+    ///
+    /// - If the module mapping pass data is not available.
+    /// - If any function to be generated is not in the module map.
+    /// - If any function has an entry-point block that has not been allocated.
+    pub fn generate_module(&self, module: &Module, data: &mut ObjectContext) -> Result<()> {
+        // We need the module map to be able to make correct code generation decisions
+        // here, so we start by grabbing this. If it doesn't exist, this is a programmer
+        // error, so we crash loudly.
+        let module_map = self.pass_data().get::<BuildModuleMap>().expect(
+            "The module mapping pass does not appear to have been run but is required for code \
+             generation.",
+        );
+
+        // We start by generating code for globals, as they are referenced in function
+        // definitions.
+        for global in module.get_globals() {
+            let global_name = global.get_name().to_str()?;
+
+            // We generate code regardless of whether it is a definition or a declaration,
+            // as we need to have something to reference regardless.
+            if let Some(global_data) = module_map.globals.get(global_name) {
+                self.generate_global(&global, global_name, global_data, data)?;
+            }
+        }
+
+        // We start by generating the entry points for every locally-defined function so
+        // that we can reference them later.
+        for function in module.get_functions() {
+            let function_name = function.get_name().to_str()?;
+
+            // If it is a DEFINITION we need to generate an entry point block for it that we
+            // can reference later.
+            if should_define_func(function_name, module_map) {
+                let block_id = data.flo.new_empty_block();
+                data.module_functions.insert(function_name.to_string(), block_id);
+            }
+        }
+
+        // We then go through our functions, as these are the things we actually need to
+        // generate code for.
+        for function in module.get_functions() {
+            let function_name = function.get_name().to_str()?;
+
+            // We can only generate code for a function if it actually is _defined_.
+            // Otherwise, we just have to skip it; declarations are used for
+            // sanity checks but cannot result in generated code.
+            if should_define_func(function_name, module_map) {
+                let func_data = module_map
+                    .functions
+                    .get(function_name)
+                    .expect("Function was defined but not discovered by module mapping");
+                let entry_block_id = data
+                    .module_functions
+                    .get_by_left(function_name)
+                    .expect("Function block was allocated but missing");
+                self.generate_function(&function, *entry_block_id, function_name, func_data, data)?;
+            }
+        }
+
+        // Having generated both of these portions into the FLO, we are done for now.
+        Ok(())
+    }
+
+    /// Generates code for the provided `func`, described by `func_info`.
+    ///
+    /// Behavior will not be well-formed if `func_info` is not the function
+    /// information that corresponds to `func` at runtime.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the function cannot be generated for any reason.
+    ///
+    /// # Panics
+    ///
+    /// - If a block within the function is not known before usage time when
+    ///   generating the function.
+    pub fn generate_function(
+        &self,
+        func: &FunctionValue,
+        func_entry_id: BlockId,
+        func_name: &str,
+        func_info: &FunctionInfo,
+        data: &mut ObjectContext,
+    ) -> Result<()> {
+        // We use the function context to keep track of all the data needed to correctly
+        // generate the FLO code for the function. This includes in-scope variables.
+        let mut func_ctx = FunctionContext::new(
+            func_info.typ.clone(),
+            data.copy_module_functions(),
+            data.copy_module_globals(),
+        );
+
+        // The function signature gives us our inputs, which are necessary to be
+        // referenced later. To that end, we generate it first, as it does not depend on
+        // the availability of any blocks.
+        let sig = self.generate_signature(func_info, data, &mut func_ctx)?;
+
+        // Next we can iterate over the basic blocks in the function and create stubs
+        // for each. This means that we have targets during later generation.
+        for (ix, block) in func.get_basic_blocks().iter().enumerate() {
+            // Create a poisoned block and insert it so we have block ids to reference for
+            // control flow when building the function's blocks.
+            let block_name = block.get_name().to_str()?.to_string();
+
+            // In the case of the _first_ block, this is special as it
+            // represents a function entry, so we actually need to generate the
+            // function signature.
+            let block_id = if ix == 0 {
+                func_entry_id
+            } else {
+                data.flo.new_empty_block()
+            };
+
+            // No matter the kind of block, we need to push it into our blocks mapping to be
+            // able to create control flow properly later.
+            func_ctx.blocks.insert(block_name, block_id);
+        }
+
+        // Then we need to generate blocks themselves, passing the basic block and the
+        // block into which to generate, as well as the data context.
+        for (ix, block) in func.get_basic_blocks().iter().enumerate() {
+            let block_name = block.get_name().to_str()?;
+            let id = func_ctx.blocks.get_by_left(block_name).expect(
+                "Block was somehow not inserted into the block mapping despite existing within \
+                 this function",
+            );
+
+            // In the case of the _first_ block, this is special as it
+            // represents a function entry, so we need to insert the signature.
+            let signature = if ix == 0 { Some(&sig) } else { None };
+
+            // We also stick the function into the symbol table for future reference.
+            data.flo.symbols.code.insert(func_name.to_string(), *id);
+
+            // Now that we have the ID, we can actually perform the generation process.
+            data.flo.fill_block(*id, signature, |bb| {
+                self.generate_block(block, bb, &mut func_ctx)
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Generates a function signature using the provided `func_info`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the signature generation does not operate properly.
+    ///
+    /// # Panics
+    ///
+    /// - If the type of the function in `func_info` is not a function type.
+    /// - If any of the function arguments is missing a name.
+    /// - If any component type (parameter or return types) of `func_info` is a
+    ///   function type.
+    pub fn generate_signature(
+        &self,
+        func_info: &FunctionInfo,
+        data: &mut ObjectContext,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<Signature> {
+        let func_type = &func_info.typ;
+
+        // Convert the parameter types
+        let params = func_type
+            .parameter_types
+            .iter()
+            .zip(&func_info.param_names)
+            .map(|(t, name)| {
+                let typ = ObjectContext::flo_type_of(t)?;
+                let var_id = data.flo.add_variable(typ.clone());
+                let name = name.as_ref().expect("Function definitions must have named arguments");
+                func_ctx.register_local(var_id, name, typ);
+
+                Ok(var_id)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Then convert the return types, which is explicitly NOT a local
+        let ret_type = ObjectContext::flo_type_of(&func_type.return_type)?;
+        let return_id = data.flo.add_variable(ret_type);
+        let returns = vec![return_id];
+
+        // We are ignoring locations for now, so let's just return
+        let location = None;
+
+        Ok(Signature {
+            params,
+            returns,
+            location,
+        })
+    }
+
+    /// Generates the contents of the FLO block identified by `block_id` using
+    /// the contents of the provided `block`.
+    ///
+    /// The block corresponding to `block_id` must already have been allocated
+    /// as part of the FLO stored in `data`. If this is not done, behavior is
+    /// not well-formed.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the block cannot be generated for any reason.
+    pub fn generate_block(
+        &self,
+        block: &BasicBlock,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        let last_instruction_ix = block.get_instructions().count() - 1;
+        for (ix, instruction) in block.get_instructions().enumerate() {
+            if ix == last_instruction_ix {
+                // We are the final instruction in our block, so we need to
+                // build the block exit.
+                self.generate_block_exit(instruction, bb, func_ctx)?;
+            } else {
+                self.generate_instruction(instruction, bb, func_ctx)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Generates code for the global definition provided as `global` and
+    /// described by `global_info`.
+    ///
+    /// Behavior will not be well-formed if `global_info` is not the global
+    /// information that corresponds to `global` at runtime.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the global cannot be generated for any reason.
+    pub fn generate_global(
+        &self,
+        global: &GlobalValue,
+        global_name: &str,
+        global_info: &GlobalInfo,
+        data: &mut ObjectContext,
+    ) -> Result<()> {
+        // Now we can start by creating a variable for our variable.
+        let llvm_type = &global_info.typ;
+        let flo_type = ObjectContext::flo_type_of(llvm_type)?;
+        let linkage = ObjectContext::linkage_of(&global_info.linkage, global_name);
+        let global_variable = Variable {
+            typ: flo_type,
+            linkage,
+            poison: PoisonType::None,
+            diagnostics: Vec::new(),
+            location: None,
+        };
+        let global_id = data.flo.variables.insert(&global_variable);
+
+        // With the identifier, we need to shove it into the module globals.
+        data.module_globals.insert(global_name.to_string(), global_id);
+
+        // Next, we need to add it to the symbol table if it is something with external
+        // visibility.
+        if matches!(global_info.visibility, GlobalVisibility::Default) {
+            data.flo.symbols.data.insert(global_name.to_string(), global_id);
+        }
+
+        // While we now have a variable definition that can be referenced elsewhere, the
+        // variable is inherently uninitialized. FLO provides an "initializers"
+        // mechanism that provides blocks that are executed by the CRT0.
+        if let Some(_initializer_code) = global.get_initializer() {
+            // TODO (#24) Actually implement this.
+        }
+
+        Ok(())
+    }
+}
+
+/// These functions implement generation for individual opcodes that are
+/// classified as _non-terminator_ instructions.
+impl ObjectGenerator {
+    /// Generates a FLO statement that corresponds to the provided
+    /// `instruction`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the statement cannot be generated for any reason.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is a terminator instruction (see
+    ///   [`is_non_terminator_instruction`] for more information).
+    pub fn generate_instruction(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        #[allow(clippy::enum_glob_use)] // We do actually use all of them here.
+        use InstructionOpcode::*;
+
+        // Start by grabbing the opcode and checking that it is not a terminator
+        // instruction and hence something we can handle here. If it isn't, we just need
+        // to bail.
+        let opcode = instruction.get_opcode();
+        assert!(is_non_terminator_instruction(opcode));
+
+        // LLVM likes to use anonymous names for certain instructions, so if we find one
+        // of those we have to give it an _actual_ name. These names are allocated from
+        // the code generator's fresh name supply.
+        //
+        // Note that, as the underlying IR is implemented as a linked graph, this
+        // changes the name for all USAGES of the named instruction as well.
+        if let Some(n) = instruction.get_name() {
+            if n.is_empty() {
+                let new_name = self.allocate_name();
+                instruction.set_name(new_name.as_str())?;
+            }
+        }
+
+        // Then we need to correctly process the opcode into the correct piece of
+        // functionality, most of which end up being polyfills here.
+        match &opcode {
+            Add => unimplemented!("Add"),
+            AddrSpaceCast => unimplemented!("AddrSpaceCast"),
+            Alloca => self.generate_alloca(instruction, bb, func_ctx),
+            And => unimplemented!("And"),
+            AShr => unimplemented!("AShr"),
+            AtomicCmpXchg => unimplemented!("AtomicCmpXchg"),
+            AtomicRMW => unimplemented!("AtomicRMW"),
+            BitCast => unimplemented!("BitCast"),
+            Call => self.generate_call(instruction, bb, func_ctx),
+            CatchPad => unimplemented!("CatchPad"),
+            CleanupPad => unimplemented!("CleanupPad"),
+            ExtractValue => self.generate_extract_value(instruction, bb, func_ctx),
+            FNeg => unimplemented!("FNeg"),
+            FAdd => unimplemented!("FAdd"),
+            FCmp => unimplemented!("FCmp"),
+            FDiv => unimplemented!("FDiv"),
+            Fence => unimplemented!("Fence"),
+            FMul => unimplemented!("FMul"),
+            FPExt => unimplemented!("FPExt"),
+            FPToSI => unimplemented!("FPToSI"),
+            FPToUI => unimplemented!("FPToUI"),
+            FPTrunc => unimplemented!("FPTrunc"),
+            Freeze => unimplemented!("Freeze"),
+            FRem => unimplemented!("FRem"),
+            FSub => unimplemented!("FSub"),
+            GetElementPtr => unimplemented!("GetElementPtr"),
+            ICmp => unimplemented!("ICmp"),
+            InsertValue => unimplemented!("InsertValue"),
+            IntToPtr => unimplemented!("IntToPtr"),
+            LandingPad => unimplemented!("LandingPad"),
+            Load => unimplemented!("Load"),
+            LShr => unimplemented!("LShr"),
+            Mul => unimplemented!("Mul"),
+            Or => unimplemented!("Or"),
+            Phi => unimplemented!("Phi"),
+            PtrToInt => unimplemented!("PtrToInt"),
+            SDiv => unimplemented!("SDiv"),
+            Select => unimplemented!("Select"),
+            SExt => unimplemented!("SExt"),
+            Shl => unimplemented!("Shl"),
+            SIToFP => unimplemented!("SIToFP"),
+            SRem => unimplemented!("SRem"),
+            Store => self.generate_store(instruction, bb, func_ctx),
+            Sub => unimplemented!("Sub"),
+            Trunc => unimplemented!("Trunc"),
+            UDiv => unimplemented!("UDiv"),
+            UIToFP => unimplemented!("UIToFP"),
+            URem => unimplemented!("URem"),
+            VAArg => unimplemented!("VAArg"),
+            Xor => unimplemented!("Xor"),
+            ZExt => unimplemented!("ZExt"),
+            ExtractElement | InsertElement | ShuffleVector => {
+                Err(Error::UnsupportedOpcode(opcode))?
+            }
+            _ => unreachable!(
+                "The opcode has already been checked to ensure it is not a terminator instruction"
+            ),
+        }
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [extractvalue](https://llvm.org/docs/LangRef.html#extractvalue-instruction)
+    /// instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ an `extractvalue`.
+    /// - If the `extractvalue` opcode had more than one non-index operand.
+    /// - If the `extractvalue` opcode did not have any indices.
+    /// - If any extraction index is out of bounds for the number of fields in
+    ///   the type being extracted from.
+    #[allow(clippy::unused_self)] // For consistency with the majority of generate_* methods
+    fn generate_extract_value(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::ExtractValue),
+            "The argument to generate_extract_value was not an extract value instruction"
+        );
+
+        // We start by grabbing the operand. Confusingly this looks like it has two, but
+        // only the value from which to extract (which must have a struct type) is an
+        // actual operand.
+        let &[operand] = extract_value_operands(instruction)?.as_slice() else {
+            Err(Error::malformed_llvm(
+                "The extractvalue instruction had more than one direct operand",
+            ))?
+        };
+        let input_struct = func_ctx
+            .lookup_variable(operand.get_name().to_str()?)
+            .expect("Operand was used but not defined");
+
+        // We then get the indices from which to extract value(s), though we are
+        // currently not supporting more than one index.
+        let &[index] = get_indices(&instruction)
+            .expect("extractvalue did not have indices but must")
+            .as_slice()
+        else {
+            Err(Error::malformed_llvm(
+                "We do not currently support multiple indices",
+            ))?
+        };
+
+        // Destructuring in FLO is always complete, so we need a variable for every slot
+        // in the type.
+        let var_type = bb.context.variables.get(input_struct).typ;
+        let struct_types = match var_type {
+            Type::Struct(struct_type) => struct_type.members.clone(),
+            _ => Err(Error::malformed_llvm(
+                "Extractvalue called on non-struct type",
+            ))?,
+        };
+
+        let process_struct_ty = |(ix, ty): (usize, &Type)| -> Result<VariableId> {
+            if ix == index.try_into().expect("Index exceeded bounds") {
+                // We only care about the one we are actually extracting so it gets registered
+                // with its name.
+                let out_var_name = instruction
+                    .get_name()
+                    .expect("Instruction should be named at this point")
+                    .to_str()?;
+                let out_var_id = bb.add_variable(ty.clone());
+                let expected_llvm_type = LLVMType::try_from(instruction.get_type())?;
+                let expected_flo_type = &ObjectContext::flo_type_of(&expected_llvm_type)?;
+                if expected_flo_type != ty {
+                    Err(Error::TypeMismatch(
+                        format!("{expected_flo_type:?}"),
+                        format!("{ty:?}"),
+                    ))?;
+                }
+                func_ctx.register_local(out_var_id, out_var_name, ty.clone());
+                Ok(out_var_id)
+            } else {
+                // In the other cases these are dead, so we never register them in the
+                // function's local scope.
+                let var = Variable {
+                    typ:         ty.clone(),
+                    linkage:     VariableLinkage::Unspecified,
+                    poison:      PoisonType::Unused,
+                    diagnostics: Vec::new(),
+                    location:    None,
+                };
+                Ok(bb.context.variables.insert(&var))
+            }
+        };
+
+        let out_vars = struct_types
+            .iter()
+            .enumerate()
+            .map(process_struct_ty)
+            .collect::<Result<Vec<_>>>()?;
+
+        // Now we can actually insert the destructure in question.
+        bb.simple_destructure(input_struct, out_vars);
+
+        Ok(())
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [call](https://llvm.org/docs/LangRef.html#call-instruction) instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ a `call`.
+    /// - If any name is used before being defined.
+    fn generate_call(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Call),
+            "The argument to generate_call was not a call instruction"
+        );
+
+        // Let's start by grabbing the function being called, which is always the LAST
+        // operand to the call instruction.
+        let num_operands = instruction.get_num_operands();
+        let func_ptr_value = extract_value_operand(
+            instruction.get_operand(num_operands - 1),
+            InstructionOpcode::Call,
+        )?;
+        let function_name = expect_func_name_from_bv(func_ptr_value);
+
+        // There are certain unfortunate functions that need to be handled specially, so
+        // we have to check if this is one of these, and drop it entirely if so.
+        let special_intrinsics = SpecialIntrinsics::new();
+        if special_intrinsics.info_for(&function_name).is_some() {
+            return Ok(());
+        }
+
+        // If it is NOT one of these, we have to actually generate the call, and to do
+        // that we need to know whether it is an internal or external call.
+        let function_ref = if let Some(id) = func_ctx.module_functions().get_by_left(&function_name)
+        {
+            BlockRef::Local(*id)
+        } else if let Some(polyfill_name) = self.polyfills.polyfill(&function_name) {
+            BlockRef::Builtin(polyfill_name.to_string())
+        } else {
+            BlockRef::External(function_name)
+        };
+
+        // We then need to put together the operands by grabbing the variables from the
+        // context and passing them in. Given that the function name is the LAST
+        // operand, it is the one we want to ignore.
+        let args = instruction
+            .get_operands()
+            .collect_vec()
+            .split_last()
+            .map(|(_, args)| args.to_vec())
+            .unwrap_or_default();
+        let arg_names = args
+            .into_iter()
+            .map(|a| {
+                let op = extract_value_operand(a, instruction.get_opcode())?;
+                name_from_bv(op)?
+                    .ok_or(Error::malformed_llvm("Operand to call did not have a name"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let inputs = arg_names
+            .into_iter()
+            .map(|name| {
+                func_ctx
+                    .lookup_variable(&name)
+                    .unwrap_or_else(|| panic!("Name {name} was used before being defined"))
+            })
+            .collect_vec();
+
+        // We also the need to handle providing the return value, if one exists, using
+        // the type and whether the instruction has a name telling us.
+        let outputs = if let Some(name) = instruction.get_name() {
+            let output_name = name.to_str()?.to_string();
+            let instruction_type = LLVMType::try_from(instruction.get_type())?;
+            let flo_type = ObjectContext::flo_type_of(&instruction_type)?;
+            let output_var = bb.add_variable(flo_type.clone());
+            func_ctx.register_local(output_var, &output_name, flo_type);
+            vec![output_var]
+        } else {
+            Vec::new()
+        };
+
+        // We have no diagnostics or locations for now.
+        let diagnostics = Vec::default();
+        let location = None;
+
+        // Finally, we can build the call itself.
+        bb.call(&function_ref, inputs, outputs, diagnostics, location);
+
+        Ok(())
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [store](https://llvm.org/docs/LangRef.html#store-instruction)
+    /// instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ a `store`.
+    /// - If any name is used before being defined.
+    pub fn generate_store(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Store),
+            "The argument to generate_store was not a store instruction"
+        );
+
+        // We start by grabbing the operands, and checking that they are already
+        // defined and have the expected types.
+        let value_operands = extract_value_operands(instruction)?;
+        let operands = name_type_pairs_from_value_operands(&value_operands)?;
+        let operands = operands
+            .iter()
+            .map(|(name, ty)| {
+                let flo_type = ObjectContext::flo_type_of(ty)?;
+                let var_id = func_ctx
+                    .lookup_variable(name)
+                    .expect("Variable was not defined before its usage");
+                let var_def = bb.context.variables.get(var_id);
+                if flo_type != var_def.typ {
+                    Err(Error::TypeMismatch(
+                        format!("{flo_type:?}"),
+                        format!("{v_ty:?}", v_ty = var_def.typ),
+                    ))?;
+                }
+
+                Ok(var_id)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Let's get the name of the corresponding builtin and prepare our arguments
+        let name = self.polyfills.polyfill_or_err("store")?;
+        let returns = vec![];
+
+        // Finally we can generate the operation into the block.
+        bb.simple_call_builtin(name, operands, returns);
+
+        Ok(())
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [alloca](https://llvm.org/docs/LangRef.html#alloca-instruction)
+    /// instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ an `alloca`.
+    /// - If the [`crate::pass::analysis::module_map::ModuleMap`] data is not
+    ///   available.
+    /// - If the `alloca` instruction does not have a type to allocate.
+    /// - If the `alloca` instruction does not have a count of that type to
+    ///   allocate.
+    pub fn generate_alloca(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Alloca),
+            "The argument to generate_alloca was not an alloca instruction"
+        );
+
+        // We need the data layout to properly calculate the size of the allocation.
+        let data_layout = &self
+            .pass_data
+            .get::<BuildModuleMap>()
+            .expect("Module mapping pass data was not available where it must be")
+            .data_layout;
+
+        // We can then grab the allocated type and its size.
+        let allocated_type = LLVMType::try_from(
+            instruction
+                .get_allocated_type()
+                .expect("Instruction known to be `alloca` had no allocated type"),
+        )?;
+        let type_size = allocated_type.size_of(data_layout);
+
+        // We also need to know the allocation count, which inkwell always fills in with
+        // the default of 1 for us if not otherwise specified.
+        let &[raw_alloc_count] = extract_value_operands(instruction)?.as_slice() else {
+            Err(Error::invalid_opcode_operand(
+                instruction.get_opcode(),
+                "The count operand was missing",
+            ))?
+        };
+
+        // If this is not an integer then the previous stages should have caught
+        // malformed IR.
+        let alloc_count = expect_int_from_bv(raw_alloc_count);
+
+        // We need a block reference, which here is guaranteed to be to a polyfill.
+        let call_ref = self.polyfills.polyfill_or_err("alloca")?;
+
+        // We also need arguments and returns with their types.
+        let alloc_size = bb.simple_assign_new_const(ConstantValue {
+            value: type_size as u128,
+            typ:   Type::Unsigned64,
+        });
+        let alloc_count = bb.simple_assign_new_const(ConstantValue {
+            value: alloc_count
+                .try_into()
+                .map_err(|_| Error::malformed_llvm("Alloc count for `alloca` was negative"))?,
+            typ:   Type::Unsigned64,
+        });
+        let return_val = bb.add_variable(Type::Pointer);
+
+        // Now we build our arguments to the call
+        let inputs = vec![alloc_size, alloc_count];
+        let outputs = vec![return_val];
+
+        // Then we can build the call to the allocation function and add it to the block
+        // in question.
+        bb.simple_call_builtin(call_ref, inputs, outputs);
+
+        // If this instruction assigns to an SSA variable, then we use the output
+        // variable of the function as this.
+        if let Some(name) = instruction.get_name() {
+            let name = name.to_str()?.to_string();
+            func_ctx.register_local(return_val, &name, Type::Pointer);
+        }
+
+        Ok(())
+    }
+}
+
+/// These functions implement generation for individual opcodes that are
+/// classified as _terminator_ instructions.
+impl ObjectGenerator {
+    /// Generates a FLO statement that corresponds to the provided terminator
+    /// `instruction`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`], if the statement cannot be generated for any reason.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is not a terminator instruction (see
+    ///   [`is_terminator_instruction`] for more information).
+    pub fn generate_block_exit(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        #[allow(clippy::enum_glob_use)] // We do actually use all of them here.
+        use InstructionOpcode::*;
+
+        // Start by grabbing the opcode and checking that it is indeed something we can
+        // handle as a block exit. If it isn't we just need to bail.
+        let opcode = instruction.get_opcode();
+        assert!(
+            is_terminator_instruction(opcode),
+            "Terminator instruction expected but {opcode:?} found"
+        );
+
+        // Then we need to correctly process the opcode into the correct block exit.
+        match &opcode {
+            Br => self.generate_br(instruction, bb, func_ctx),
+            IndirectBr => unimplemented!("IndirectBr"),
+            Invoke => unimplemented!("Invoke"),
+            Return => self.generate_return(instruction, bb, func_ctx),
+            Switch => unimplemented!("Switch"),
+            Unreachable => self.generate_unreachable(instruction, bb),
+            CallBr | CatchRet | CatchSwitch | CleanupRet | Resume => {
+                Err(Error::UnsupportedOpcode(opcode))?
+            }
+            _ => unreachable!(
+                "The opcode has already been checked to ensure it is a terminator instruction"
+            ),
+        }
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [unreachable](https://llvm.org/docs/LangRef.html#unreachable-instruction)
+    /// instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ an `unreachable`.
+    pub fn generate_unreachable(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Unreachable),
+            "The argument to generate_unreachable was not an unreachable instruction"
+        );
+
+        bb.set_exit(&BlockExit::Panic(
+            "Unreachable code was reachable".to_string(),
+            vec![],
+        ));
+
+        Ok(())
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [ret](https://llvm.org/docs/LangRef.html#ret-instruction) instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ a `ret`.
+    /// - If the variable to be returned does not exist in the function context.
+    pub fn generate_return(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Return),
+            "The argument to generate_ret was not a ret instruction"
+        );
+
+        // This instruction takes two forms. The first takes one operand, which is the
+        // value to return, while the other takes no operands, and just causes control
+        // flow.
+        let operands = instruction.get_operands().collect_vec();
+        let return_ids = match operands.len() {
+            0 => {
+                // When there are no operands, this is pure control flow so we return no values.
+                Vec::new()
+            }
+            1 => {
+                // When there is one operand, we are returning a specific value back.
+                let value = extract_value_operand(operands[0], InstructionOpcode::Return)?;
+                let value_name = value.get_name().to_str()?;
+                let value_type = LLVMType::try_from(value.get_type())?;
+                let expected_return_type = &func_ctx.typ().return_type;
+                assert_eq!(expected_return_type.as_ref(), &value_type);
+
+                let return_value_id = func_ctx.lookup_variable(value_name).unwrap_or_else(|| {
+                    panic!("Returned variable {value_name} does not exist in function context")
+                });
+
+                vec![return_value_id]
+            }
+            _ => Err(Error::malformed_llvm(&format!(
+                "ret instruction encountered with {len} operands where only 0 or 1 are supported",
+                len = operands.len()
+            )))?,
+        };
+
+        bb.end_with_return(return_ids);
+
+        Ok(())
+    }
+
+    /// Generates the FLO code that corresponds to an LLVM
+    /// [br](https://llvm.org/docs/LangRef.html#br-instruction) instruction.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error`] if the correct FLO representation of the instruction cannot
+    ///   be generated.
+    ///
+    /// # Panics
+    ///
+    /// - If the provided instruction is _not_ a `br`.
+    /// - If the instruction has the incorrect number of operands.
+    /// - If any target block is unknown.
+    /// - If the condition to the conditional branch is not a boolean.
+    pub fn generate_br(
+        &self,
+        instruction: InstructionValue,
+        bb: &mut BlockBuilder,
+        func_ctx: &mut FunctionContext,
+    ) -> Result<()> {
+        assert!(
+            matches!(instruction.get_opcode(), InstructionOpcode::Br),
+            "The argument to generate_br was not a br instruction"
+        );
+
+        // First we have to grab the operands to the instruction. There are two forms of
+        // the branch instruction which can be distinguished by the type of the first
+        // operand. If the first operand is a basic block, this is an unconditional
+        // branch, and if it is a value (an i1 used for the condition), it is a
+        // conditional branch.
+        let operands = instruction.get_operands().collect_vec();
+
+        let generate_unconditional_br = |bb: &mut BlockBuilder| -> Result<()> {
+            // In this case, we have to generate the UNCONDITIONAL branch.
+            let target_block = extract_block_operand(operands[0], InstructionOpcode::Br)?;
+            let target_name = target_block.get_name().to_str()?;
+            let block_id = *func_ctx.blocks.get_by_left(target_name).unwrap_or_else(|| {
+                panic!(
+                    "No block by name {target_name} was found, but should have already been \
+                     registered"
+                )
+            });
+            bb.end_with_goto(block_id);
+
+            Ok(())
+        };
+
+        let generate_conditional_br = |bb: &mut BlockBuilder| -> Result<()> {
+            // In this case we have to generate the CONDITIONAL branch.
+            let condition = extract_value_operand(operands[0], InstructionOpcode::Br)?;
+            let true_block = extract_block_operand(operands[1], InstructionOpcode::Br)?;
+            let false_block = extract_block_operand(operands[2], InstructionOpcode::Br)?;
+
+            // The condition must be an already-extant variable.
+            let cond_name = condition.get_name().to_str()?;
+            let cond_id = func_ctx
+                .lookup_variable(cond_name)
+                .expect("Condition variable did not exist");
+            if !matches!(bb.context.variables.get(cond_id).typ, Type::Bool) {
+                Err(Error::malformed_llvm(
+                    "The condition to br was not a boolean",
+                ))?;
+            }
+
+            // We should also know about each of the blocks that are targets.
+            let true_name = true_block.get_name().to_str()?;
+            let true_id = func_ctx.blocks.get_by_left(true_name).unwrap_or_else(|| {
+                panic!("br instruction contained unknown block reference {true_name}")
+            });
+            let false_name = false_block.get_name().to_str()?;
+            let false_id = func_ctx.blocks.get_by_left(false_name).unwrap_or_else(|| {
+                panic!("br instruction contained unknown block reference {true_name}")
+            });
+
+            bb.end_with_if(cond_id, *true_id, *false_id, None);
+
+            Ok(())
+        };
+
+        // Finally, we can actually process the branch instruction.
+        match operands.len() {
+            1 => generate_unconditional_br(bb),
+            3 => generate_conditional_br(bb),
+            _ => Err(Error::malformed_llvm(&format!(
+                "br instruction encountered with {len} operands where only 1 or 3 are supported",
+                len = operands.len()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use crate::{
+        context::SourceContext,
+        obj_gen::ObjectGenerator,
+        pass::data::DynPassDataMap,
+        polyfill::PolyfillMap,
+    };
+
+    #[test]
+    fn errors_on_invalid_name() -> anyhow::Result<()> {
+        let source_module = Path::new("input/add.ll");
+        let cg = ObjectGenerator::new(
+            "",
+            DynPassDataMap::new(),
+            SourceContext::create(source_module)?,
+            PolyfillMap::default(),
+        );
+
+        assert!(cg.is_err());
+
+        Ok(())
+    }
+}

--- a/crates/compiler/src/obj_gen/util.rs
+++ b/crates/compiler/src/obj_gen/util.rs
@@ -1,0 +1,269 @@
+//! This module contains miscellaneous utilities that are useful aids in
+//! generating a `FlatLoweredObject`.
+
+use hieratika_errors::compile::{Error, Result};
+use inkwell::{
+    basic_block::BasicBlock,
+    llvm_sys::core::{LLVMGetIndices, LLVMGetNumIndices},
+    values::{AsValueRef, BasicValueEnum, InstructionOpcode, InstructionValue},
+};
+use itertools::Either;
+
+use crate::{
+    llvm::{typesystem::LLVMType, TopLevelEntryKind},
+    pass::analysis::module_map::ModuleMap,
+};
+
+/// A type used for operands in inkwell.
+pub type InkwellOperand<'ctx> = Either<BasicValueEnum<'ctx>, BasicBlock<'ctx>>;
+
+/// A type used for optional operands in inkwell.
+pub type OptionalInkwellOperand<'ctx> = Option<InkwellOperand<'ctx>>;
+
+/// Returns `true` if `inst` is **not** a
+/// [terminator instruction](https://llvm.org/docs/LangRef.html#terminator-instructions)
+/// or returns `false` otherwise.
+#[must_use]
+pub fn is_non_terminator_instruction(inst: InstructionOpcode) -> bool {
+    !is_terminator_instruction(inst)
+}
+
+/// Returns `true` if `inst` is a
+/// [terminator instruction](https://llvm.org/docs/LangRef.html#terminator-instructions)
+/// or returns `false` otherwise.
+#[must_use]
+pub fn is_terminator_instruction(inst: InstructionOpcode) -> bool {
+    matches!(
+        inst,
+        InstructionOpcode::Return
+            | InstructionOpcode::Br
+            | InstructionOpcode::Switch
+            | InstructionOpcode::IndirectBr
+            | InstructionOpcode::Invoke
+            | InstructionOpcode::CallBr
+            | InstructionOpcode::Resume
+            | InstructionOpcode::CatchSwitch
+            | InstructionOpcode::CatchRet
+            | InstructionOpcode::CleanupRet
+            | InstructionOpcode::Unreachable
+    )
+}
+
+/// Extracts the value of the provided `operand` as a basic value where
+/// possible.
+///
+/// # Errors
+///
+/// - [`Error::InvalidOpcodeOperand`] when the provided operand is a basic
+///   block.
+pub fn extract_value_operand(
+    operand: OptionalInkwellOperand,
+    opcode: InstructionOpcode,
+) -> Result<BasicValueEnum> {
+    match operand {
+        Some(Either::Left(basic_value)) => Ok(basic_value),
+        Some(Either::Right(basic_block)) => {
+            let block_name = basic_block.get_name().to_str()?;
+            Err(Error::invalid_opcode_operand(
+                opcode,
+                &format!("A value was expected where basic block {block_name} was encountered"),
+            ))
+        }
+        None => Err(Error::invalid_opcode_operand(
+            opcode,
+            "No operand was found where one was required",
+        )),
+    }
+}
+
+/// Extracts the value of the provided `operand` as a basic block where
+/// possible.
+///
+/// # Errors
+///
+/// - [`Error::InvalidOpcodeOperand`] when the provided operand is a basic
+///   value.
+pub fn extract_block_operand(
+    operand: OptionalInkwellOperand,
+    opcode: InstructionOpcode,
+) -> Result<BasicBlock> {
+    match operand {
+        Some(Either::Right(basic_block)) => Ok(basic_block),
+        Some(Either::Left(basic_value)) => {
+            let value_name = basic_value.get_name().to_str()?;
+            Err(Error::invalid_opcode_operand(
+                opcode,
+                &format!("A block was expected where basic value {value_name} was encountered"),
+            ))
+        }
+        None => Err(Error::invalid_opcode_operand(
+            opcode,
+            "No operand was found where one was required",
+        )),
+    }
+}
+
+/// Extracts the operands to the provided `instruction` while asserting that
+/// they are all basic values (variants of [`BasicValueEnum`]).
+///
+/// # Errors
+///
+/// - [`Error::InvalidOpcodeOperand`] when one of the operands to `instruction`
+///   is a basic block.
+pub fn extract_value_operands(instruction: InstructionValue) -> Result<Vec<BasicValueEnum>> {
+    let opcode = instruction.get_opcode();
+    instruction
+        .get_operands()
+        .map(|operand| extract_value_operand(operand, opcode))
+        .collect::<Result<Vec<BasicValueEnum>>>()
+}
+
+/// Extracts pairs of `(name, type)` from the provided value operands.
+///
+/// # Errors
+///
+/// - [`Error::UnsupportedType`] if a scalable vector value is encountered in
+///   the provided `operands`.
+pub fn name_type_pairs_from_value_operands(
+    operands: &[BasicValueEnum],
+) -> Result<Vec<(String, LLVMType)>> {
+    // This is repetitive, but each of the elements involved has subtly different
+    // types that make extracting a function here impossible.
+    operands
+        .iter()
+        .map(|bv| match bv {
+            BasicValueEnum::ArrayValue(array_val) => {
+                let ty = LLVMType::try_from(array_val.get_type())?;
+                let name = array_val.get_name().to_str()?.to_string();
+
+                Ok((name, ty))
+            }
+            BasicValueEnum::IntValue(int_val) => {
+                let ty = LLVMType::try_from(int_val.get_type())?;
+                let name = int_val.get_name().to_str()?.to_string();
+
+                Ok((name, ty))
+            }
+            BasicValueEnum::FloatValue(float_val) => {
+                let ty = LLVMType::try_from(float_val.get_type())?;
+                let name = float_val.get_name().to_str()?.to_string();
+
+                Ok((name, ty))
+            }
+            BasicValueEnum::PointerValue(ptr_val) => {
+                let ty = LLVMType::try_from(ptr_val.get_type())?;
+                let name = ptr_val.get_name().to_str()?.to_string();
+
+                Ok((name, ty))
+            }
+            BasicValueEnum::StructValue(struct_val) => {
+                let ty = LLVMType::try_from(struct_val.get_type())?;
+                let name = struct_val.get_name().to_str()?.to_string();
+
+                Ok((name, ty))
+            }
+            BasicValueEnum::VectorValue(vector_val) => {
+                Err(Error::UnsupportedType(vector_val.to_string()))?
+            }
+        })
+        .collect()
+}
+
+/// Extracts an integer from the provided basic `value`, or returns [`None`]
+/// if `value` is non-integral.
+#[must_use]
+pub fn int_from_bv(value: BasicValueEnum) -> Option<i64> {
+    match value {
+        BasicValueEnum::IntValue(int_val) => int_val.get_sign_extended_constant(),
+        _ => None,
+    }
+}
+
+/// Extracts an integer from the provided basic `value` where possible.
+///
+/// # Panics
+///
+/// If the provided `value` is not an integral value.
+#[must_use]
+pub fn expect_int_from_bv(value: BasicValueEnum) -> i64 {
+    int_from_bv(value).expect("The provided value was not an integer")
+}
+
+/// Extracts a name from the provided basic `value`, or returns [`None`] if
+/// that `value` is not possible.
+///
+/// # Errors
+///
+/// - [`Error::CStrConversionError`] if the name cannot be converted into a
+///   rust-native String.
+pub fn name_from_bv(value: BasicValueEnum) -> Result<Option<String>> {
+    // This is repetitive, but each of the elements involved has subtly different
+    // types that make extracting a function here impossible.
+    let name = match value {
+        BasicValueEnum::PointerValue(ptr_val) => ptr_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::ArrayValue(arr_val) => arr_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::IntValue(int_val) => int_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::FloatValue(float_val) => float_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::StructValue(struct_val) => struct_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::VectorValue(vec_val) => vec_val.get_name().to_str()?.to_string(),
+    };
+
+    Ok(if name.is_empty() { None } else { Some(name) })
+}
+
+/// Extracts a function name from the provided basic `value`.
+///
+/// # Panics
+///
+/// If the provided value is not a pointer representing a function value.
+#[must_use]
+pub fn expect_func_name_from_bv(value: BasicValueEnum) -> String {
+    name_from_bv(value)
+        .expect("Name could not be converted")
+        .expect("No name was available")
+}
+
+/// Returns `true` if the function with the provided `name` should be
+/// defined as part of this module, and `false` otherwise.
+#[must_use]
+pub fn should_define_func(name: &str, module_map: &ModuleMap) -> bool {
+    if let Some(function_data) = module_map.functions.get(name) {
+        matches!(function_data.kind, TopLevelEntryKind::Definition)
+    } else {
+        false
+    }
+}
+
+/// Gets the indices from the LLVM instruction if it has them, or returns
+/// [`None`] if it does not.
+///
+/// For this to be valid to call, the instruction needs to be either the
+/// [`InstructionOpcode::ExtractValue`] or
+/// [`InstructionOpcode::InsertValue`] opcodes.
+///
+/// # Panics
+///
+/// If any struct index exceeds the bounds of [`isize`].
+#[must_use]
+pub fn get_indices(instruction: &InstructionValue) -> Option<Vec<u64>> {
+    match instruction.get_opcode() {
+        InstructionOpcode::ExtractValue | InstructionOpcode::InsertValue => {
+            let instruction_value = instruction.as_value_ref();
+
+            unsafe {
+                let num_indices = LLVMGetNumIndices(instruction_value);
+                let indices = LLVMGetIndices(instruction_value);
+
+                let mut output_indices = Vec::with_capacity(num_indices as usize);
+                for i in 0..num_indices {
+                    let i_converted: isize = i.try_into().expect("Struct index was far too large");
+                    let index = *indices.offset(i_converted);
+                    output_indices.push(u64::from(index));
+                }
+
+                Some(output_indices)
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/compiler/src/pass/analysis/module_map.rs
+++ b/crates/compiler/src/pass/analysis/module_map.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 
+use ethnum::U256;
 use hieratika_errors::compile::{Error, Result};
 use inkwell::{
     module::{Linkage, Module},
@@ -20,7 +21,7 @@ use crate::{
     llvm::{
         data_layout::DataLayout,
         special_intrinsics::SpecialIntrinsics,
-        typesystem::LLVMType,
+        typesystem::{LLVMFunction, LLVMType},
         TopLevelEntryKind,
     },
     pass::{
@@ -91,6 +92,9 @@ impl BuildModuleMap {
     ///
     /// - [`Error`] if the module cannot be mapped successfully.
     pub fn map_module(&mut self, module: &Module) -> Result<ModuleMap> {
+        // First, we grab the module name.
+        let module_name = module.get_name().to_str()?;
+
         // We start by analyzing the data-layout of the module, which is important to
         // ensure that things match later on and that we are not being asked for things
         // that we do not or cannot support. This _may_ currently return errors due to
@@ -100,7 +104,7 @@ impl BuildModuleMap {
 
         // With our data layout obtained successfully, we can build our module map and
         // start adding top-level entries to it.
-        let mut mod_map = ModuleMap::new(data_layout);
+        let mut mod_map = ModuleMap::new(module_name, data_layout);
 
         // We then process the global definitions in scope and gather the relevant
         // information about them.
@@ -184,6 +188,16 @@ impl BuildModuleMap {
         let visibility = global.get_visibility();
         let is_initialized = global.get_initializer().is_some();
 
+        // LLVM IR's [LangRef](https://llvm.org/docs/LangRef.html#global-variables)
+        // states that definitions of global variables must have initializers. Only
+        // declarations of globals in other translation units may not be accompanied by
+        // an initializer.
+        if !is_initialized && kind == TopLevelEntryKind::Definition {
+            Err(Error::malformed_llvm(
+                "Definitions of constants in LLVM IR must have initializers",
+            ))?;
+        }
+
         let global_info = GlobalInfo {
             kind,
             typ,
@@ -191,7 +205,6 @@ impl BuildModuleMap {
             visibility,
             alignment,
             is_const,
-            is_initialized,
         };
 
         mod_map.globals.insert(name, global_info);
@@ -216,14 +229,24 @@ impl BuildModuleMap {
             } else {
                 TopLevelEntryKind::Definition
             };
-            let typ = LLVMType::try_from(func.get_type())?;
+            let typ = LLVMFunction::try_from(func.get_type())?;
             let linkage = func.get_linkage();
             let intrinsic = func.get_intrinsic_id() != 0;
             let visibility = func.as_global_value().get_visibility();
+            let param_names = func
+                .get_params()
+                .iter()
+                .map(|p| {
+                    let name = p.get_name().to_str()?.to_string();
+                    Ok(if name.is_empty() { None } else { Some(name) })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
             let f_info = FunctionInfo {
                 kind,
                 intrinsic,
                 typ,
+                param_names,
                 linkage,
                 visibility,
             };
@@ -272,11 +295,15 @@ impl ConcretePass for BuildModuleMap {
 ///
 /// It contains information on the module's:
 ///
+/// - Name, useful for identifying the module in question.
 /// - Data layout, as given by the embedded data layout string.
 /// - Functions, as given by the function definitions and declarations.
 /// - Globals, as given by the global definitions and declarations.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleMap {
+    /// The name for the module.
+    pub module_name: String,
+
     /// The data layout provided for this module.
     pub data_layout: DataLayout,
 
@@ -289,11 +316,30 @@ pub struct ModuleMap {
 
 impl ModuleMap {
     /// Creates a new instance of the output data for the module mapping pass.
+    ///
+    /// # Anonymous Modules
+    ///
+    /// If the module is anonymous—in other words that its name is an empty
+    /// string—it will have a name generated at random. Please note that the
+    /// underlying RNG **cannot be relied upon to be cryptographically secure**,
+    /// and should not be treated as such.
     #[must_use]
-    pub fn new(data_layout: DataLayout) -> Self {
+    pub fn new(name: &str, data_layout: DataLayout) -> Self {
+        let module_name = if name.is_empty() {
+            // This _is_ actually cryptographically secure, but the fact that it is (see the
+            // docs on `ThreadRng` for more details), is an implementation detail and need
+            // not be sustained through changes.
+            let rand_bytes: [u8; size_of::<U256>()] = rand::random();
+            let rand_num = U256::from_be_bytes(rand_bytes);
+            format!("{rand_num:#032x}")
+        } else {
+            name.to_string()
+        };
         let functions = HashMap::new();
         let globals = HashMap::new();
+
         Self {
+            module_name,
             data_layout,
             globals,
             functions,
@@ -303,8 +349,8 @@ impl ModuleMap {
     /// Creates a new trait object of the output data for the module mapping
     /// pass.
     #[must_use]
-    pub fn new_dyn(data_layout: DataLayout) -> Box<Self> {
-        Box::new(Self::new(data_layout))
+    pub fn new_dyn(name: &str, data_layout: DataLayout) -> Box<Self> {
+        Box::new(Self::new(name, data_layout))
     }
 }
 
@@ -328,12 +374,23 @@ pub struct FunctionInfo {
     pub intrinsic: bool,
 
     /// The LLVM type of our function.
-    pub typ: LLVMType,
+    pub typ: LLVMFunction,
+
+    /// The parameter names for the function, if they exist.
+    pub param_names: Vec<Option<String>>,
 
     /// The linkage for our function.
+    ///
+    /// For more information, see the
+    /// [LLVM Documentation](https://llvm.org/docs/LangRef.html#linkage-types)
+    /// on linkage.
     pub linkage: Linkage,
 
     /// The visibility of our function.
+    ///
+    /// For more information, see the
+    /// [LLVM Documentation](https://llvm.org/docs/LangRef.html#visibility-styles)
+    /// on visibility.
     pub visibility: GlobalVisibility,
 }
 
@@ -348,9 +405,17 @@ pub struct GlobalInfo {
     pub typ: LLVMType,
 
     /// The linkage for our global.
+    ///
+    /// For more information, see the
+    /// [LLVM Documentation](https://llvm.org/docs/LangRef.html#linkage-types)
+    /// on linkage.
     pub linkage: Linkage,
 
     /// The visibility of our global.
+    ///
+    /// For more information, see the
+    /// [LLVM Documentation](https://llvm.org/docs/LangRef.html#visibility-styles)
+    /// on visibility.
     pub visibility: GlobalVisibility,
 
     /// The alignment of the global value.
@@ -358,9 +423,6 @@ pub struct GlobalInfo {
 
     /// `true` if this global is constant, and `false` otherwise.
     pub is_const: bool,
-
-    /// `true` if this global is initialized, and `false` otherwise.
-    pub is_initialized: bool,
 }
 
 #[cfg(test)]
@@ -371,8 +433,17 @@ mod test {
 
     use crate::{
         context::SourceContext,
-        llvm::{data_layout::DataLayout, typesystem::LLVMType, TopLevelEntryKind},
-        pass::{analysis::module_map::BuildModuleMap, data::DynPassDataMap, ConcretePass, PassOps},
+        llvm::{
+            data_layout::DataLayout,
+            typesystem::{LLVMFunction, LLVMType},
+            TopLevelEntryKind,
+        },
+        pass::{
+            analysis::module_map::{BuildModuleMap, ModuleMap},
+            data::DynPassDataMap,
+            ConcretePass,
+            PassOps,
+        },
     };
 
     /// A utility function to make it easy to load the testing context in all
@@ -380,6 +451,14 @@ mod test {
     fn get_text_context() -> SourceContext {
         SourceContext::create(Path::new(r"input/add.ll"))
             .expect("Unable to construct testing source context")
+    }
+
+    #[test]
+    fn generates_random_names_for_anon_modules() {
+        let map_1 = ModuleMap::new("", DataLayout::new("").unwrap());
+        let map_2 = ModuleMap::new("", DataLayout::new("").unwrap());
+
+        assert_ne!(map_1.module_name, map_2.module_name);
     }
 
     #[test]
@@ -457,7 +536,6 @@ mod test {
         let global_1 = globals
             .get(&"alloc_4190527422e5cc48a15bd1cb4f38f425".to_string())
             .unwrap();
-        assert!(global_1.is_initialized);
         assert_eq!(global_1.visibility, GlobalVisibility::Default);
         assert_eq!(global_1.alignment, 1);
         assert!(global_1.is_const);
@@ -473,7 +551,6 @@ mod test {
         let global_2 = globals
             .get(&"alloc_5b4544c775a23c08ca70c48dd7be27fc".to_string())
             .unwrap();
-        assert!(global_2.is_initialized);
         assert_eq!(global_2.visibility, GlobalVisibility::Default);
         assert_eq!(global_2.alignment, 8);
         assert!(global_2.is_const);
@@ -518,52 +595,72 @@ mod test {
         assert_eq!(rust_test_input.visibility, GlobalVisibility::Default);
         assert_eq!(
             rust_test_input.typ,
-            LLVMType::make_function(LLVMType::i64, &[LLVMType::i64, LLVMType::i64])
+            LLVMFunction::new(LLVMType::i64, &[LLVMType::i64, LLVMType::i64])
+        );
+        assert_eq!(
+            rust_test_input.param_names,
+            vec![Some("left".into()), Some("right".into())]
         );
 
         // llvm.dbg.declare
-        let rust_test_input = functions.get(&"llvm.dbg.declare".to_string()).unwrap();
-        assert!(rust_test_input.intrinsic);
-        assert_eq!(rust_test_input.kind, TopLevelEntryKind::Declaration);
-        assert_eq!(rust_test_input.linkage, Linkage::External);
-        assert_eq!(rust_test_input.visibility, GlobalVisibility::Default);
+        let llvm_dbg_declare = functions.get(&"llvm.dbg.declare".to_string()).unwrap();
+        assert!(llvm_dbg_declare.intrinsic);
+        assert_eq!(llvm_dbg_declare.kind, TopLevelEntryKind::Declaration);
+        assert_eq!(llvm_dbg_declare.linkage, Linkage::External);
+        assert_eq!(llvm_dbg_declare.visibility, GlobalVisibility::Default);
         assert_eq!(
-            rust_test_input.typ,
-            LLVMType::make_function(
+            llvm_dbg_declare.typ,
+            LLVMFunction::new(
                 LLVMType::void,
                 &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata]
             )
         );
+        assert_eq!(llvm_dbg_declare.param_names, vec![None, None, None]);
 
         // llvm.uadd.with.overflow.i64
-        let rust_test_input = functions.get(&"llvm.uadd.with.overflow.i64".to_string()).unwrap();
-        assert!(rust_test_input.intrinsic);
-        assert_eq!(rust_test_input.kind, TopLevelEntryKind::Declaration);
-        assert_eq!(rust_test_input.linkage, Linkage::External);
-        assert_eq!(rust_test_input.visibility, GlobalVisibility::Default);
+        let llvm_uadd_with_overflow_i64 =
+            functions.get(&"llvm.uadd.with.overflow.i64".to_string()).unwrap();
+        assert!(llvm_uadd_with_overflow_i64.intrinsic);
         assert_eq!(
-            rust_test_input.typ,
-            LLVMType::make_function(
+            llvm_uadd_with_overflow_i64.kind,
+            TopLevelEntryKind::Declaration
+        );
+        assert_eq!(llvm_uadd_with_overflow_i64.linkage, Linkage::External);
+        assert_eq!(
+            llvm_uadd_with_overflow_i64.visibility,
+            GlobalVisibility::Default
+        );
+        assert_eq!(
+            llvm_uadd_with_overflow_i64.typ,
+            LLVMFunction::new(
                 LLVMType::make_struct(false, &[LLVMType::i64, LLVMType::bool]),
                 &[LLVMType::i64, LLVMType::i64]
             )
         );
+        assert_eq!(llvm_uadd_with_overflow_i64.param_names, vec![None, None]);
 
         // _ZN4core9panicking11panic_const24panic_const_add_overflow17he7771b1d81fa091aE
-        let rust_test_input = functions
+        let panic_const_add_overflow = functions
             .get(
                 &"_ZN4core9panicking11panic_const24panic_const_add_overflow17he7771b1d81fa091aE"
                     .to_string(),
             )
             .unwrap();
-        assert!(!rust_test_input.intrinsic);
-        assert_eq!(rust_test_input.kind, TopLevelEntryKind::Declaration);
-        assert_eq!(rust_test_input.linkage, Linkage::External);
-        assert_eq!(rust_test_input.visibility, GlobalVisibility::Default);
+        assert!(!panic_const_add_overflow.intrinsic);
         assert_eq!(
-            rust_test_input.typ,
-            LLVMType::make_function(LLVMType::void, &[LLVMType::ptr])
+            panic_const_add_overflow.kind,
+            TopLevelEntryKind::Declaration
         );
+        assert_eq!(panic_const_add_overflow.linkage, Linkage::External);
+        assert_eq!(
+            panic_const_add_overflow.visibility,
+            GlobalVisibility::Default
+        );
+        assert_eq!(
+            panic_const_add_overflow.typ,
+            LLVMFunction::new(LLVMType::void, &[LLVMType::ptr])
+        );
+        assert_eq!(panic_const_add_overflow.param_names, vec![None]);
 
         Ok(())
     }

--- a/crates/compiler/src/polyfill/mappings.rs
+++ b/crates/compiler/src/polyfill/mappings.rs
@@ -2,11 +2,17 @@
 //! compiler.
 //!
 //! These constants are left undocumented as they have extremely self-describing
-//! names.
+//! names, but we do try to define them in alphabetical order.
 
 /// A pair where the left element is the LLVM-side name, and the right side is
 /// the expected name for the polyfill.
 type PolyPair<'a> = (&'a str, &'a str);
+
+pub const LLVM_ALLOCA: PolyPair<'static> = ("alloca", "_llvm_alloca");
+
+pub const LLVM_FENCE: PolyPair<'static> = ("fence", "_llvm_fence");
+
+pub const LLVM_STORE: PolyPair<'static> = ("store", "_llvm_store");
 
 pub const LLVM_UADD_WITH_OVERFLOW_I64: PolyPair<'static> = (
     "llvm.uadd.with.overflow.i64",

--- a/crates/compiler/tests/common/mod.rs
+++ b/crates/compiler/tests/common/mod.rs
@@ -1,0 +1,21 @@
+//! Common utilities for the integration tests, these are intended to make it
+//! easier to write complex tests of the compiler's functionality.
+
+use std::path::Path;
+
+use hieratika_compiler::{context::SourceContext, Compiler, CompilerBuilder};
+
+/// Creates a compiler—with default settings for passes and polyfills—wrapping
+/// the module at the provided `path`.
+///
+/// # Errors
+///
+/// - [`anyhow::Error`] if the path does not exist.
+/// - [`ltc_errors::compiler::Error`] if the compiler cannot load the file at
+///   `path` as LLVM IR.
+pub fn default_compiler_from_path(path: &str) -> anyhow::Result<Compiler> {
+    let path = Path::new(path);
+    let ctx = SourceContext::create(path)?;
+
+    Ok(CompilerBuilder::new(ctx).build())
+}

--- a/crates/compiler/tests/compilation_basic_add.rs
+++ b/crates/compiler/tests/compilation_basic_add.rs
@@ -1,0 +1,84 @@
+//! Tests compilation of the `add.ll` IR file to check that we generate the
+//! expected FLO output.
+
+use hieratika_flo::types::{BlockExit, Type};
+use itertools::Itertools;
+
+mod common;
+
+#[test]
+fn compiles_add() -> anyhow::Result<()> {
+    // We start by constructing and running the compiler
+    let compiler = common::default_compiler_from_path("input/add.ll")?;
+    let flo = compiler.run()?;
+
+    // The number of blocks should be three at minimum, as this is how many explicit
+    // blocks there are, but we may see up to five additional blocks used in the
+    // compilation flow.
+    let num_blocks = flo.blocks.iter().count();
+    assert!(num_blocks >= 3);
+    assert!(num_blocks <= 8);
+
+    // We should only see one function in this generation, even if there are lots of
+    // blocks.
+    let num_functions = flo.blocks.iter().filter(|(_, b)| b.signature.is_some()).count();
+    assert_eq!(num_functions, 1);
+
+    // Let's grab that one function and poke at it a bit.
+    let (_, hieratika_rust_test_input) =
+        flo.blocks.iter().find(|(_, b)| b.signature.is_some()).unwrap();
+
+    // It should have 11 statements in its body
+    assert_eq!(hieratika_rust_test_input.statements.len(), 11);
+
+    // It should also end with a conditional branch instruction, which in FLO looks
+    // like a match.
+    assert!(matches!(
+        hieratika_rust_test_input.exit,
+        BlockExit::Match(_)
+    ));
+
+    // That match can end up in one of two places, so let's start by grabbing it.
+    let exit = &hieratika_rust_test_input.exit;
+    let target_block_ids = match exit {
+        BlockExit::Match(arms) => arms
+            .iter()
+            .map(|arm_id| {
+                let arm = flo.match_arms.get(*arm_id);
+                arm.target_block
+            })
+            .collect_vec(),
+        _ => unreachable!("Already known to be a BlockExit::Match"),
+    };
+
+    // One of these should have no statements in its body.
+    let (_, bb1) = flo
+        .blocks
+        .iter()
+        .find(|(id, b)| target_block_ids.contains(id) && b.statements.is_empty())
+        .unwrap();
+
+    // Its exit should be a return of an i64 variable.
+    let exit = &bb1.exit;
+    match exit {
+        BlockExit::Return(vars) => {
+            assert_eq!(vars.len(), 1);
+            let var = &vars[0];
+            let typ = flo.variables.get(*var).typ;
+            assert_eq!(typ, Type::Signed64);
+        }
+        _ => panic!("Incorrect exit type from basic block 1"),
+    };
+
+    // The other of them should have one statement in its body.
+    let (_, panic) = flo
+        .blocks
+        .iter()
+        .find(|(id, b)| target_block_ids.contains(id) && b.statements.len() == 1)
+        .unwrap();
+
+    // Its exit should be unreachable, which we translate as a panic.
+    assert!(matches!(panic.exit, BlockExit::Panic(_, _)));
+
+    Ok(())
+}

--- a/crates/error/src/compile.rs
+++ b/crates/error/src/compile.rs
@@ -3,7 +3,7 @@
 
 use std::str::Utf8Error;
 
-use inkwell::support::LLVMString;
+use inkwell::{support::LLVMString, values::InstructionOpcode};
 use thiserror::Error;
 
 /// The result type for use in the compiler.
@@ -28,10 +28,20 @@ pub enum Error {
     #[error("`{_0}` with invalid segment `{_1}` could not be parsed as an LLVM data layout")]
     InvalidDataLayoutSpecification(String, String),
 
+    /// Emitted when the compilation process discovers an invalid type of
+    /// operand for the opcode in question.
+    #[error("Encountered an invalid operand for opcode {_0:?}: {_1}")]
+    InvalidOpcodeOperand(InstructionOpcode, String),
+
     /// Emitted when code tries to construct an invalid ordering of compiler
     /// passes.
     #[error("Invalid Pass Ordering: {_0}")]
     InvalidPassOrdering(String),
+
+    /// Emitted when code tries to convert between types in a way that is
+    /// invalid.
+    #[error("Could not convert types: {_0}")]
+    InvalidTypeConversion(String),
 
     /// An error when doing IO during compilation.
     #[error(transparent)]
@@ -44,25 +54,106 @@ pub enum Error {
     #[error("LLVM Error: {_0}")]
     LLVMError(String),
 
+    /// Emitted when encountering malformed LLVM IR.
+    #[error("The LLVM IR was malformed: {_0}")]
+    MalformedLLVM(String),
+
+    /// Emitted when a module was not given any kind of name during the code
+    /// generation process.
+    #[error("The module had a missing name during code generation")]
+    MissingModuleName,
+
+    /// Emitted when a polyfill is requested for an LLVM-side name, but none was
+    /// made available in the polyfill mapping.
+    #[error("No polyfill was available for the LLVM name {_0}")]
+    MissingPolyfill(String),
+
+    /// Emitted when a global value that is not `constant` is discovered.
+    #[error("The global with name `{_0}` is non-constant, but we only support constant globals")]
+    NonConstantGlobal(String),
+
+    /// Emitted when a mismatch is found between types.
+    #[error("{_0} != {_1} but were expected to be equal")]
+    TypeMismatch(String, String),
+
     /// Emitted when an attempt is made to add a module to the compilation
     /// context, but cannot do soe compilation context, but cannot do so.
     #[error("Unable to add module to context: {_0}")]
     UnableToAddModuleToContext(String),
 
+    /// Emitted when the target data layout specifies more than one address
+    /// space.
     #[error("We only support targets that use a single address space numbered 0")]
     UnsupportedAdditionalAddressSpaces,
 
-    #[error("We do not support targets with non-integral pointers configured.")]
+    /// Emitted when the target data layout requests non-integral pointer
+    /// configuration.
+    #[error("We do not support targets with non-integral pointers configured")]
     UnsupportedNonIntegralPointerConfiguration,
+
+    /// Emitted when encountering an LLVM opcode that we do not currently
+    /// support.
+    #[error("The LLVM opcode `{_0:?}` is not currently supported")]
+    UnsupportedOpcode(InstructionOpcode),
 
     /// Emitted when we encounter an LLVM type that we do not support.
     #[error("The LLVM basic type {_0} is not supported")]
     UnsupportedType(String),
 }
 
+impl Error {
+    /// Generates [`Self::InvalidOpcodeOperand`] while being able to take
+    /// [`&str`] as the argument for ease of use.
+    pub fn invalid_opcode_operand(opcode: InstructionOpcode, message: &str) -> Self {
+        Self::InvalidOpcodeOperand(opcode, message.to_string())
+    }
+
+    /// Generates [`Self::InvalidTypeConversion`] while being able to take
+    /// [`&str`] as the argument for ease of use.
+    pub fn invalid_type_conversion(message: &str) -> Self {
+        Self::InvalidTypeConversion(message.to_string())
+    }
+
+    /// Generates [`Self::MalformedLLVM`] while being able to take [`&str`] as
+    /// the argument for ease of use.
+    pub fn malformed_llvm(message: &str) -> Self {
+        Self::MalformedLLVM(message.to_string())
+    }
+
+    /// Generates [`Self::MissingPolyfill`] while being able to take [`&str`] as
+    /// the argument for ease of use.
+    pub fn missing_polyfill(name: &str) -> Self {
+        Self::MissingPolyfill(name.to_string())
+    }
+
+    /// Generates [`Self::NonConstantGlobal`] while being able to take [`&str`]
+    /// as the argument for ease of use.
+    pub fn non_constant_global(message: &str) -> Self {
+        Self::NonConstantGlobal(message.to_string())
+    }
+
+    /// Generates [`Self::TypeMismatch`] while being able to take [`&str`] as
+    /// the arguments for ease of use.
+    pub fn type_mismatch(type_a: &str, type_b: &str) -> Self {
+        Self::TypeMismatch(type_a.to_string(), type_b.to_string())
+    }
+
+    /// Generates [`Self::UnsupportedType`] while being able to take [`&str`] as
+    /// the argument for ease of use.
+    pub fn unsupported_type(message: &str) -> Self {
+        Self::UnsupportedType(message.to_string())
+    }
+}
+
 impl From<LLVMString> for Error {
     /// Wrap an error from LLVM into our error type.
     fn from(value: LLVMString) -> Self {
+        Self::LLVMError(value.to_string())
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
         Self::LLVMError(value.to_string())
     }
 }

--- a/crates/flo/src/builders.rs
+++ b/crates/flo/src/builders.rs
@@ -185,8 +185,7 @@ impl<'a> BlockBuilder<'a> {
     pub(crate) fn build(mut self, into: Option<BlockId>) -> BlockId {
         // Before we insert the block, we'll set its poison to indicate if it's now
         // ready to use.
-        let is_incomplete =
-            self.block.statements.is_empty() || BlockExit::is_poisoned(&self.block.exit);
+        let is_incomplete = BlockExit::is_poisoned(&self.block.exit);
         self.block.poison = if is_incomplete {
             PoisonType::Incomplete
         } else {

--- a/crates/flo/src/flo.rs
+++ b/crates/flo/src/flo.rs
@@ -382,9 +382,10 @@ impl FlatLoweredObject {
     pub fn fill_block<E>(
         &mut self,
         id: BlockId,
+        signature: Option<&Signature>,
         f: impl FnOnce(&mut BlockBuilder) -> Result<(), E>,
     ) -> Result<(), E> {
-        self.insert_or_create_block(Some(id), None, f)?;
+        self.insert_or_create_block(Some(id), signature, f)?;
         self.assert_block_not_poisoned(id);
 
         Ok(())

--- a/crates/flo/src/intern.rs
+++ b/crates/flo/src/intern.rs
@@ -121,6 +121,15 @@ where
 
         previous.expect("internal consistency error: swap called on an unknown ID!")
     }
+
+    /// Gets an immutable iterator over the entries in the table.
+    ///
+    /// Please note that neither the zero entry nor the poison entry will be
+    /// an element seen in the iterator, and so it is not recommended to
+    /// construct a new `InternTable` by `collect`ing this iterator.
+    pub fn iter(&self) -> impl Iterator<Item = (&usize, &ValueType)> {
+        self.table.iter().filter(|(id, _)| **id != POISON_ENTRY && **id != 0)
+    }
 }
 
 impl<IdType, ValueType> Default for InternTable<IdType, ValueType>

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -78,6 +78,9 @@ pub enum PoisonType {
     /// should not ever be accessed.
     Unreachable,
 
+    /// Indicates a value that is never read from.
+    Unused,
+
     /// This **special case** is the value of the Null interned entry, which
     /// sits at 0 and tries to prevent logic bugs.
     NullInternedValue,

--- a/crates/flo/tests/flo_test.rs
+++ b/crates/flo/tests/flo_test.rs
@@ -50,7 +50,7 @@ fn flos_are_the_same_after_round_trip() -> anyhow::Result<()> {
     })?;
 
     // In the zero path, we have a bock that just returns '1'.
-    flo.fill_block(block_is_zero, |b| -> anyhow::Result<()> {
+    flo.fill_block(block_is_zero, None, |b| -> anyhow::Result<()> {
         // Create the return value of '1'...
         let retval = b.add_variable(Type::Unsigned32);
         b.simple_assign_const(retval, const_u32(1));
@@ -62,7 +62,7 @@ fn flos_are_the_same_after_round_trip() -> anyhow::Result<()> {
     })?;
 
     // In the non-zero path, we compute mul(i, sub(i, 1)), and return that.
-    flo.fill_block(block_is_nonzero, |b| -> anyhow::Result<()> {
+    flo.fill_block(block_is_nonzero, None, |b| -> anyhow::Result<()> {
         // Create the '1' we'll use in subtract...
         let const_one = b.add_variable(Type::Unsigned32);
         b.simple_assign_const(const_one, const_u32(1));

--- a/crates/rust-test-input/src/lib.rs
+++ b/crates/rust-test-input/src/lib.rs
@@ -4,3 +4,8 @@
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
+
+/// Subtracts two numbers from each other.
+pub fn sub(left: i8, right: i8) -> i8 {
+    left - right
+}


### PR DESCRIPTION
# Summary

This commit adds the `ObjectGenerator` and the related support types, as well as performing the basic plumbing of it into the compilation flow.

It performs enough compilation to be able to compile the _most basic_ of the examples we have available, but will explicitly crash on anything else.

# Details

Anything you see fit! Please be nit-picky. There's a lot of code, and while not much of it is complicated, it is still a lot to understand all at once.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
