### PR TITLE
Implement additional opcodes

### DIFF
--- a/crates/cairoc/src/lib.rs
+++ b/crates/cairoc/src/lib.rs
@@ -147,7 +147,6 @@ mod test {
                     .extension()
                     .map_or(false, |ext| ext.eq_ignore_ascii_case("cairo"))
                 {
-                    println!("Flat lowered {:?}", file.path());
                     generate_flat_lowered(&file.path()).unwrap();
                 }
             });

--- a/crates/compiler/input/opcodes.ll
+++ b/crates/compiler/input/opcodes.ll
@@ -1,0 +1,22 @@
+; ModuleID = 'opcodes.ll'
+source_filename = "opcodes.ll"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-none"
+
+define i64 @hieratika_test_add(i64 %left, i64 %right) unnamed_addr {
+start:
+  %0 = add nuw nsw i64 %left, %right
+  ret i64 %0
+}
+
+define i8 @hieratika_test_and(i8 %left, i8 %right) unnamed_addr {
+start:
+  %0 = and i8 %left, %right
+  ret i8 %0
+}
+
+define i32 @hieratika_test_sub(i32 %left, i32 %right) unnamed_addr {
+start:
+  %0 = sub nuw nsw i32 %left, %right
+  ret i32 %0
+}

--- a/crates/compiler/src/obj_gen/data.rs
+++ b/crates/compiler/src/obj_gen/data.rs
@@ -162,11 +162,11 @@ impl ObjectContext {
             LLVMType::i32 => Type::Signed32,
             LLVMType::i64 => Type::Signed64,
             LLVMType::i128 => Type::Signed128,
-            LLVMType::half => Err(Error::invalid_type_conversion(
+            LLVMType::f16 => Err(Error::invalid_type_conversion(
                 "We do not currently support half-precision floats",
             ))?,
-            LLVMType::float => Type::Float,
-            LLVMType::double => Type::Double,
+            LLVMType::f32 => Type::Float,
+            LLVMType::f64 => Type::Double,
             LLVMType::ptr => Type::Pointer,
             LLVMType::void => Type::Void,
             LLVMType::Array(array) => array_to_flo(array)?,

--- a/crates/compiler/src/polyfill/mappings.rs
+++ b/crates/compiler/src/polyfill/mappings.rs
@@ -18,3 +18,5 @@ pub const LLVM_UADD_WITH_OVERFLOW_I64: PolyPair<'static> = (
     "llvm.uadd.with.overflow.i64",
     "__llvm_uadd_with_overflow_i64_i64",
 );
+
+pub const LLVM_ADD_I64: PolyPair<'static> = ("add.i64", "__llvm_add_i64_i64");

--- a/crates/compiler/src/polyfill/mod.rs
+++ b/crates/compiler/src/polyfill/mod.rs
@@ -53,186 +53,1192 @@
 
 pub mod mappings;
 
-use bimap::{BiHashMap, BiMap};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+};
+
 use hieratika_errors::compile::llvm::{Error, Result};
+use itertools::Itertools;
 
-use crate::polyfill::mappings::{LLVM_ALLOCA, LLVM_FENCE, LLVM_STORE, LLVM_UADD_WITH_OVERFLOW_I64};
+use crate::llvm::typesystem::LLVMType;
 
-/// A bidirectional mapping from the builtin names for LLVM to the internal
-/// names for the corresponding polyfills.
+/// Generates a binary operation with the provided `name` and with a type
+/// equivalent to  `a -> a -> a`.
+macro_rules! binop {
+    ($name:ident, $tys:ident) => {
+        fn $name(&mut self) {
+            for typ in Self::$tys() {
+                self.mk(stringify!($name), &[typ.clone(), typ.clone()], typ.clone());
+            }
+        }
+    };
+}
+
+/// Generates a unary intrinsic with the provided `name` and with a type
+/// equivalent to `a -> a`.
+macro_rules! unary_intrinsic {
+    ($name:ident, $tys:ident) => {
+        fn $name(&mut self) {
+            let base_name = format!("llvm.{}", stringify!($name));
+            for typ in Self::$tys() {
+                let name = format!("{base_name}.{typ}");
+                let arg_types = &[typ.clone()];
+                let return_type = typ.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    };
+}
+
+/// Generates a binary intrinsic with the provided `name` and with a type
+/// equivalent to either `a -> a -> a` in the first case, or `a -> a -> b` in
+/// the second.
+macro_rules! binary_intrinsic {
+    ($name:ident, $tys:ident) => {
+        fn $name(&mut self) {
+            let base_name = format!("llvm.{}", stringify!($name));
+            for typ in Self::$tys() {
+                let name = format!("{base_name}.{typ}");
+                let arg_types = &[typ.clone(), typ.clone()];
+                let return_type = typ.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    };
+    ($name:ident, $tys:ident, $fixed_ret:expr) => {
+        fn $name(&mut self) {
+            let base_name = format!("llvm.{}", stringify!($name));
+            for typ in Self::$tys() {
+                let name = format!("{base_name}.{}.{typ}", $fixed_ret.clone());
+                let arg_types = &[typ.clone(), typ.clone()];
+                let return_type = $fixed_ret;
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    };
+}
+
+/// A mapping between a specifically-typed opcode instance and the corresponding
+/// polyfill name.
+pub type PolyMapping = HashMap<LLVMOperation, String>;
+
+/// An opcode instance with its types fully specified, used to map specific
+/// instances of opcodes or intrinsics to the specific output polyfill name.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LLVMOperation {
+    /// The name of the operation.
+    pub opcode_name: String,
+
+    /// The types of the operands to the operation.
+    pub operand_types: Vec<LLVMType>,
+
+    /// The return type of the operation.
+    ///
+    /// This should only be set to [`None`] if the return type cannot be
+    /// determined without program analysis.
+    pub return_type: Option<LLVMType>,
+}
+
+impl LLVMOperation {
+    /// Creates an opcode representing the operation with the given `name`,
+    /// parameter types `ops`, and return-type `ret`.
+    #[must_use]
+    pub fn of(name: &str, ops: &[LLVMType], ret: LLVMType) -> Self {
+        Self {
+            opcode_name:   name.to_string(),
+            operand_types: ops.to_vec(),
+            return_type:   Some(ret),
+        }
+    }
+
+    /// Creates an opcode representing the operation with the given `name`,
+    /// parameter types `ops`, and an unknown return type (as this may require
+    /// compilation information to determine).
+    #[must_use]
+    pub fn of_dyn_ret(name: &str, ops: &[LLVMType]) -> Self {
+        Self {
+            opcode_name:   name.to_string(),
+            operand_types: ops.to_vec(),
+            return_type:   None,
+        }
+    }
+}
+
+/// To make it easier to visualize these operations without compromising the
+/// structural debug output.
+impl Display for LLVMOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let args_str = self
+            .operand_types
+            .iter()
+            .map(std::string::ToString::to_string)
+            .join(" -> ");
+        let ret_str = self
+            .return_type
+            .as_ref()
+            .map_or("()".to_string(), std::string::ToString::to_string);
+        write!(f, "{} : {} -> {}", self.opcode_name, args_str, ret_str)
+    }
+}
+
+/// A mapping from the builtin names for LLVM to the internal names for the
+/// corresponding polyfills.
 ///
 /// This exists in order to enable external linkage of symbols not part of the
 /// current translation unit.
 ///
 /// # LLVM Opcodes
 ///
-/// Note that some LLVM opcodes (e.g. `add`) map to potentially multiple
-/// implementations. For such opcodes, the expected LLVM name is given by the
-/// [`Self::of_opcode`] function.
+/// Essentially every opcode maps to multiple potential polyfill names. For the
+/// canonical encoding of these names, please check the function generating the
+/// name in question, as the rules are not entirely standardized between
+/// polyfill types.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PolyfillMap {
-    /// A mapping from the LLVM-side names to the corresponding polyfill names.
-    mapping: BiMap<String, String>,
+    mapping: PolyMapping,
 }
 
 impl PolyfillMap {
-    /// Constructs a new polyfill map from the provided `mapping`.
+    /// Instantiates a new polyfill mapping containing the polyfill definitions
+    /// _required_ for compilation.
     #[must_use]
-    pub fn new(mapping: BiHashMap<String, String>) -> Self {
+    pub fn new() -> Self {
+        let mapping = PolyMapping::new();
+        let mut polyfills = Self { mapping };
+
+        polyfills.all_unary_ops();
+        polyfills.all_binary_ops();
+        polyfills.all_bitwise_binary_ops();
+        polyfills.all_memory_ops();
+        polyfills.all_conversion_ops();
+        polyfills.all_other_ops();
+        polyfills.all_c_intrinsics();
+        polyfills.all_bit_intrinsics();
+        polyfills.all_arith_with_overflow_intrinsics();
+        polyfills.all_arith_with_sat_intrinsics();
+        polyfills.all_fixed_point_arith_intrinsics();
+        polyfills.all_specialized_arith_intrinsics();
+        polyfills.all_hp_float_intrinsics();
+        polyfills.all_sat_fptoi_conversions();
+
+        polyfills
+    }
+
+    /// Gets an immutable iterator over the mapping pairs in this polyfill
+    /// mapping.
+    pub fn iter(&self) -> impl Iterator<Item = (&LLVMOperation, &String)> {
+        self.mapping.iter()
+    }
+
+    /// Queries for the polyfill name that corresponds to the provided
+    /// `name`, `param_types` and `return_type` returning it if it exists or
+    /// returning [`None`] otherwise.
+    #[must_use]
+    pub fn polyfill(
+        &self,
+        name: &str,
+        param_types: &[LLVMType],
+        return_type: Option<&LLVMType>,
+    ) -> Option<&String> {
+        let op = LLVMOperation {
+            opcode_name:   name.to_string(),
+            operand_types: param_types.to_vec(),
+            return_type:   return_type.cloned(),
+        };
+
+        self.mapping.get(&op)
+    }
+
+    /// Queries for the polyfill name that corresponds to the provided
+    /// `name`, `param_types` and `return_type` returning it if it exists or
+    /// returning an error otherwise.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::MissingPolyfill`] if the requested polyfill does not exist.
+    pub fn polyfill_or_err(
+        &self,
+        name: &str,
+        param_types: &[LLVMType],
+        return_type: Option<&LLVMType>,
+    ) -> Result<&String> {
+        self.polyfill(name, param_types, return_type)
+            .ok_or(Error::missing_polyfill(name))
+    }
+
+    /// Queries for the polyfill name that corresponds to the provided
+    /// `name`, `param_types` and `return_type` returning it if it exists.
+    ///
+    /// # Panics
+    ///
+    /// If no polyfill exists for the provided combination of `name`,
+    /// `param_types` and `return_type`.
+    #[must_use]
+    pub fn expect_polyfill(
+        &self,
+        name: &str,
+        param_types: &[LLVMType],
+        return_type: Option<&LLVMType>,
+    ) -> &String {
+        self.polyfill(name, param_types, return_type)
+            .unwrap_or_else(|| panic!("{name} polyfill was not present"))
+    }
+}
+
+/// Functionality useful for testing and experimenting with this container.
+#[cfg(test)]
+impl PolyfillMap {
+    /// Instantiates an empty polyfill mapping.
+    ///
+    /// This **should never be used** in the compiler itself, and exists only
+    /// for testing.
+    #[must_use]
+    pub fn empty() -> Self {
+        let mapping = PolyMapping::new();
         Self { mapping }
     }
 
-    /// Queries for the polyfill name that corresponds to the provided
-    /// `llvm_name`, returning it if it exists or returning [`None`] otherwise.
+    /// Adds a specified `operation` and polyfill name pair to the map for
+    /// testing purposes.
+    pub fn insert(&mut self, operation: LLVMOperation, poly_name: &str) {
+        self.mapping.insert(operation, poly_name.to_string());
+    }
+}
+
+/// The definition of the [unary operations](https://llvm.org/docs/LangRef.html#unary-operations).
+impl PolyfillMap {
+    fn all_unary_ops(&mut self) {
+        self.fneg();
+    }
+
+    fn fneg(&mut self) {
+        for typ in Self::float_types() {
+            self.mk("fneg", &[typ.clone()], typ.clone());
+        }
+    }
+}
+
+/// The definition of the [binary operations](https://llvm.org/docs/LangRef.html#binary-operations).
+impl PolyfillMap {
+    binop!(add, integer_types);
+
+    binop!(fadd, float_types);
+
+    binop!(sub, integer_types);
+
+    binop!(fsub, float_types);
+
+    binop!(mul, integer_types);
+
+    binop!(fmul, float_types);
+
+    binop!(udiv, integer_types);
+
+    binop!(sdiv, float_types);
+
+    binop!(fdiv, float_types);
+
+    binop!(urem, integer_types);
+
+    binop!(srem, integer_types);
+
+    binop!(frem, float_types);
+
+    fn all_binary_ops(&mut self) {
+        self.add();
+        self.fadd();
+        self.sub();
+        self.fsub();
+        self.mul();
+        self.fmul();
+        self.udiv();
+        self.sdiv();
+        self.fdiv();
+        self.urem();
+        self.srem();
+        self.frem();
+    }
+}
+
+/// The definition of the [bitwise binary operations](https://llvm.org/docs/LangRef.html#bitwise-binary-operations).
+impl PolyfillMap {
+    binop!(shl, integer_types);
+
+    binop!(lshr, integer_types);
+
+    binop!(ashr, integer_types);
+
+    binop!(and, integer_types);
+
+    binop!(or, integer_types);
+
+    binop!(xor, integer_types);
+
+    fn all_bitwise_binary_ops(&mut self) {
+        self.shl();
+        self.lshr();
+        self.ashr();
+        self.and();
+        self.or();
+        self.xor();
+    }
+}
+
+/// The definition of the [memory access and addressing operations](https://llvm.org/docs/LangRef.html#memory-access-and-addressing-operations).
+impl PolyfillMap {
+    fn alloca(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        self.mk("alloca", &[LLVMType::i64, LLVMType::i64], LLVMType::ptr);
+    }
+
+    fn load(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        self.mk_dyn_ret("load", &[LLVMType::i64, LLVMType::ptr]);
+    }
+
+    fn store(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        self.mk("store", &[LLVMType::i64, LLVMType::ptr], LLVMType::void);
+    }
+
+    fn cmpxchg(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        for typ in Self::intptr_types() {
+            self.mk(
+                "cmpxchg",
+                &[LLVMType::ptr, typ.clone(), typ.clone()],
+                LLVMType::make_struct(false, &[typ.clone(), LLVMType::bool]),
+            );
+        }
+    }
+
+    fn atomicrmw(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        let op_name = "atomicrmw";
+
+        // Some of the ops are available to numeric types and pointers
+        let numptr_ops = vec!["xchg"];
+        for op in numptr_ops {
+            for typ in Self::numptr_types() {
+                let op_name = format!("{op_name}_{op}");
+                self.mk(&op_name, &[LLVMType::ptr, typ.clone()], typ.clone());
+            }
+        }
+
+        // The vast majority are available only to integer types.
+        #[rustfmt::skip]
+        let int_ops = vec![
+            "add", "sub",  "and",  "nand",      "or",        "xor",       "max",
+            "min", "umax", "umin", "uinc_wrap", "udec_wrap", "usub_cond", "usub_sat",
+        ];
+        for op in int_ops {
+            for typ in Self::integer_types() {
+                let op_name = format!("{op_name}_{op}");
+                self.mk(&op_name, &[LLVMType::ptr, typ.clone()], typ.clone());
+            }
+        }
+
+        // The remaining are available to float types.
+        let float_ops = vec!["fadd", "fsub", "fmax", "fmin"];
+        for op in float_ops {
+            for typ in Self::float_types() {
+                let op_name = format!("{op_name}_{op}");
+                self.mk(&op_name, &[LLVMType::ptr, typ.clone()], typ.clone());
+            }
+        }
+    }
+
+    fn getelementptr(&mut self) {
+        // TODO (#29) Make this comply with the design for the memory model.
+        self.mk_dyn_ret("getelementptr", &[LLVMType::ptr, LLVMType::i64]);
+    }
+
+    fn all_memory_ops(&mut self) {
+        self.alloca();
+        self.load();
+        self.store();
+        self.cmpxchg();
+        self.atomicrmw();
+        self.getelementptr();
+    }
+}
+
+/// The definition of the [conversion operations](https://llvm.org/docs/LangRef.html#conversion-operations).
+impl PolyfillMap {
+    fn trunc_op(&mut self) {
+        for source_ty in Self::integer_types().iter().rev() {
+            for target_ty in Self::integer_types().iter().take_while(|ty| *ty != source_ty) {
+                let op = LLVMOperation::of("trunc", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_trunc_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn zext(&mut self) {
+        for source_ty in Self::integer_types() {
+            for target_ty in Self::integer_types()
+                .iter()
+                .skip_while(|ty| *ty != &source_ty)
+                .skip(1)
+            {
+                let op = LLVMOperation::of("zext", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_zext_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn sext(&mut self) {
+        for source_ty in Self::integer_types() {
+            for target_ty in Self::integer_types()
+                .iter()
+                .skip_while(|ty| *ty != &source_ty)
+                .skip(1)
+            {
+                let op = LLVMOperation::of("sext", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_sext_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn fptrunc(&mut self) {
+        for source_ty in Self::float_types().iter().rev() {
+            for target_ty in Self::float_types().iter().take_while(|ty| *ty != source_ty) {
+                let op = LLVMOperation::of("fptrunc", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_fptrunc_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn fpext(&mut self) {
+        for source_ty in Self::float_types() {
+            for target_ty in Self::float_types().iter().skip_while(|ty| *ty != &source_ty).skip(1) {
+                let op = LLVMOperation::of("fpext", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_fpext_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn fptoui(&mut self) {
+        for source_ty in Self::float_types() {
+            for target_ty in Self::integer_types() {
+                let op = LLVMOperation::of("fptoui", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_fptoui_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn fptosi(&mut self) {
+        for source_ty in Self::float_types() {
+            for target_ty in Self::integer_types() {
+                let op = LLVMOperation::of("fptosi", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_fptosi_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn uitofp(&mut self) {
+        for source_ty in Self::integer_types() {
+            for target_ty in Self::integer_types() {
+                let op = LLVMOperation::of("uitofp", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_uitofp_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn sitofp(&mut self) {
+        for source_ty in Self::integer_types() {
+            for target_ty in Self::integer_types() {
+                let op = LLVMOperation::of("sitofp", &[source_ty.clone()], target_ty.clone());
+                let name = format!("__llvm_sitofp_{source_ty}_to_{target_ty}");
+                self.mapping.insert(op, name);
+            }
+        }
+    }
+
+    fn ptrtoint(&mut self) {
+        for target_ty in Self::integer_types() {
+            let source_ty = LLVMType::ptr;
+            let op = LLVMOperation::of("ptrtoint", &[source_ty.clone()], target_ty.clone());
+            let name = format!("__llvm_ptrtoint_{source_ty}_to_{target_ty}");
+            self.mapping.insert(op, name);
+        }
+    }
+
+    fn inttoptr(&mut self) {
+        for source_ty in Self::integer_types() {
+            let target_ty = LLVMType::ptr;
+            let op = LLVMOperation::of("inttoptr", &[source_ty.clone()], target_ty.clone());
+            let name = format!("__llvm_inttoptr_{source_ty}_to_{target_ty}");
+            self.mapping.insert(op, name);
+        }
+    }
+
+    fn all_conversion_ops(&mut self) {
+        self.trunc_op();
+        self.zext();
+        self.sext();
+        self.fptrunc();
+        self.fpext();
+        self.fptoui();
+        self.fptosi();
+        self.uitofp();
+        self.sitofp();
+        self.ptrtoint();
+        self.inttoptr();
+    }
+}
+
+/// The definition of the [other instructions](https://llvm.org/docs/LangRef.html#other-operations).
+impl PolyfillMap {
+    fn icmp(&mut self) {
+        let ops = vec![
+            "eq", "ne", "ugt", "uge", "ult", "ule", "sgt", "sge", "slt", "sle",
+        ];
+
+        for op in ops {
+            let name = format!("icmp_{op}");
+            for typ in Self::intptr_types() {
+                self.mk(&name, &[typ.clone(), typ.clone()], LLVMType::bool);
+            }
+        }
+    }
+
+    fn fcmp(&mut self) {
+        let ops = vec![
+            "false", "oeq", "ogt", "oge", "olt", "ole", "one", "ord", "ueq", "ugt", "uge", "ult",
+            "ule", "une", "uno", "true",
+        ];
+
+        for op in ops {
+            let name = format!("fcmp_{op}");
+            for typ in Self::float_types() {
+                self.mk(&name, &[typ.clone(), typ.clone()], LLVMType::bool);
+            }
+        }
+    }
+
+    fn all_other_ops(&mut self) {
+        self.icmp();
+        self.fcmp();
+    }
+}
+
+/// The definition of the [C/C++ library intrinsics](https://llvm.org/docs/LangRef.html#standard-c-c-library-intrinsics).
+impl PolyfillMap {
+    binary_intrinsic!(abs, integer_types);
+
+    binary_intrinsic!(smax, integer_types);
+
+    binary_intrinsic!(smin, integer_types);
+
+    binary_intrinsic!(umax, integer_types);
+
+    binary_intrinsic!(umin, integer_types);
+
+    binary_intrinsic!(scmp, integer_types, LLVMType::i8);
+
+    binary_intrinsic!(ucmp, integer_types, LLVMType::i8);
+
+    unary_intrinsic!(sqrt, float_types);
+
+    unary_intrinsic!(sin, float_types);
+
+    unary_intrinsic!(cos, float_types);
+
+    unary_intrinsic!(tan, float_types);
+
+    unary_intrinsic!(asin, float_types);
+
+    unary_intrinsic!(acos, float_types);
+
+    unary_intrinsic!(atan, float_types);
+
+    unary_intrinsic!(atan2, float_types);
+
+    unary_intrinsic!(sinh, float_types);
+
+    unary_intrinsic!(cosh, float_types);
+
+    unary_intrinsic!(tanh, float_types);
+
+    unary_intrinsic!(exp, float_types);
+
+    unary_intrinsic!(exp2, float_types);
+
+    unary_intrinsic!(exp10, float_types);
+
+    unary_intrinsic!(log, float_types);
+
+    unary_intrinsic!(log10, float_types);
+
+    unary_intrinsic!(log2, float_types);
+
+    unary_intrinsic!(fabs, float_types);
+
+    binary_intrinsic!(minnum, float_types);
+
+    binary_intrinsic!(maxnum, float_types);
+
+    binary_intrinsic!(minimum, float_types);
+
+    binary_intrinsic!(maximum, float_types);
+
+    binary_intrinsic!(minimumnum, float_types);
+
+    binary_intrinsic!(maximumnum, float_types);
+
+    binary_intrinsic!(copysign, float_types);
+
+    unary_intrinsic!(floor, float_types);
+
+    unary_intrinsic!(ceil, float_types);
+
+    unary_intrinsic!(trunc, float_types);
+
+    unary_intrinsic!(rint, float_types);
+
+    unary_intrinsic!(nearbyint, float_types);
+
+    unary_intrinsic!(round, float_types);
+
+    unary_intrinsic!(roundeven, float_types);
+
+    fn memop(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}.p0.p0");
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{typ}");
+            let arg_types = &[LLVMType::ptr, LLVMType::ptr, typ.clone(), LLVMType::bool];
+            let return_type = LLVMType::void;
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn memset(&mut self, inline: bool) {
+        let base_name = if inline {
+            "llvm.memset.inline.p0"
+        } else {
+            "llvm.memset.p0"
+        };
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{typ}");
+            let arg_types = &[LLVMType::ptr, LLVMType::i8, typ.clone(), LLVMType::bool];
+            let return_type = LLVMType::void;
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn powi(&mut self) {
+        let base_name = "llvm.powi";
+        for base_ty in Self::float_types() {
+            for exponent_ty in Self::integer_types() {
+                let name = format!("{base_name}.{}.{}", &base_ty, &exponent_ty);
+                let arg_types = &[base_ty.clone(), exponent_ty.clone()];
+                let return_type = base_ty.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    }
+
+    fn sincos(&mut self) {
+        let base_name = "llvm.sincos";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{typ}");
+            let arg_types = &[typ.clone()];
+            let return_type = LLVMType::make_struct(false, &[typ.clone(), typ.clone()]);
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn pow(&mut self) {
+        let base_name = "llvm.pow";
+        for base_ty in Self::float_types() {
+            for exponent_ty in Self::float_types() {
+                let name = format!("{base_name}.{}.{}", &base_ty, &exponent_ty);
+                let arg_types = &[base_ty.clone(), exponent_ty.clone()];
+                let return_type = base_ty.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    }
+
+    fn ldexp(&mut self) {
+        let base_name = "llvm.ldexp";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}.{}", &typ, LLVMType::i32);
+            let arg_types = &[typ.clone(), LLVMType::i32];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn frexp(&mut self) {
+        let base_name = "llvm.frexp";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}.{}", &typ, LLVMType::i32);
+            let arg_types = &[typ.clone()];
+            let return_type = LLVMType::make_struct(false, &[typ.clone(), LLVMType::i32]);
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn fma(&mut self) {
+        let base_name = "llvm.fma";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone(), typ.clone()];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn round_to(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}");
+        for source_typ in Self::float_types() {
+            for target_typ in Self::integer_types() {
+                let name = format!("{base_name}.{}.{}", &target_typ, &source_typ);
+                let arg_types = &[source_typ.clone()];
+                let return_type = target_typ.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    }
+
+    fn all_c_intrinsics(&mut self) {
+        self.abs();
+        self.smax();
+        self.smin();
+        self.umax();
+        self.umin();
+        self.scmp();
+        self.ucmp();
+        self.memop("memcpy");
+        self.memop("memcpy.inline");
+        self.memop("memmove");
+        self.memset(false);
+        self.memset(true);
+        self.sqrt();
+        self.powi();
+        self.sin();
+        self.cos();
+        self.tan();
+        self.asin();
+        self.acos();
+        self.atan();
+        self.atan2();
+        self.sinh();
+        self.cosh();
+        self.tanh();
+        self.sincos();
+        self.pow();
+        self.exp();
+        self.exp2();
+        self.exp10();
+        self.ldexp();
+        self.frexp();
+        self.log();
+        self.log10();
+        self.log2();
+        self.fma();
+        self.fabs();
+        self.minnum();
+        self.maxnum();
+        self.minimum();
+        self.maximum();
+        self.minimumnum();
+        self.maximumnum();
+        self.copysign();
+        self.floor();
+        self.ceil();
+        self.trunc();
+        self.rint();
+        self.nearbyint();
+        self.round();
+        self.roundeven();
+        self.round_to("lround");
+        self.round_to("llround");
+        self.round_to("lrint");
+        self.round_to("llrint");
+    }
+}
+
+/// The definition of the [bit manipulation intrinsics](https://llvm.org/docs/LangRef.html#bit-manipulation-intrinsics).
+impl PolyfillMap {
+    unary_intrinsic!(bitreverse, integer_types);
+
+    unary_intrinsic!(bswap, integer_types);
+
+    unary_intrinsic!(ctpop, integer_types);
+
+    fn count_op(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}");
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), LLVMType::bool];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn fsh(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}");
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone(), typ.clone()];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_bit_intrinsics(&mut self) {
+        self.bitreverse();
+        self.bswap();
+        self.ctpop();
+        self.count_op("ctlz");
+        self.count_op("cttz");
+        self.fsh("fshl");
+        self.fsh("fshr");
+    }
+}
+
+/// The definition of the [arithmetic with overflow intrinsics](https://llvm.org/docs/LangRef.html#arithmetic-with-overflow-intrinsics).
+impl PolyfillMap {
+    fn arith_with_overflow(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}.with.overflow");
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone()];
+            let return_type = LLVMType::make_struct(false, &[typ.clone(), LLVMType::bool]);
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_arith_with_overflow_intrinsics(&mut self) {
+        self.arith_with_overflow("sadd");
+        self.arith_with_overflow("uadd");
+        self.arith_with_overflow("ssub");
+        self.arith_with_overflow("usub");
+        self.arith_with_overflow("smul");
+        self.arith_with_overflow("umul");
+    }
+}
+
+/// The definition of the [saturation arithmetic intrinsics](https://llvm.org/docs/LangRef.html#saturation-arithmetic-intrinsics).
+impl PolyfillMap {
+    fn arith_with_sat(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}.sat");
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone()];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_arith_with_sat_intrinsics(&mut self) {
+        self.arith_with_sat("sadd");
+        self.arith_with_sat("uadd");
+        self.arith_with_sat("ssub");
+        self.arith_with_sat("usub");
+        self.arith_with_sat("sshl");
+        self.arith_with_sat("ushl");
+    }
+}
+
+/// The definition of the [fixed point arithmetic intrinsics](https://llvm.org/docs/LangRef.html#fixed-point-arithmetic-intrinsics).
+impl PolyfillMap {
+    fn fix_arith(&mut self, name: &str, saturating: bool) {
+        let base_name = if saturating {
+            format!("llvm.{name}.fix.sat")
+        } else {
+            format!("llvm.{name}.fix")
+        };
+        for typ in Self::integer_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone(), LLVMType::i32];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_fixed_point_arith_intrinsics(&mut self) {
+        self.fix_arith("smul", false);
+        self.fix_arith("umul", false);
+        self.fix_arith("smul", true);
+        self.fix_arith("umul", true);
+        self.fix_arith("sdiv", false);
+        self.fix_arith("udiv", false);
+        self.fix_arith("sdiv", true);
+        self.fix_arith("udiv", true);
+    }
+}
+
+/// The definition of the [specialized arithmetic intrinsics](https://llvm.org/docs/LangRef.html#specialized-arithmetic-intrinsics).
+impl PolyfillMap {
+    fn fmuladd(&mut self) {
+        let base_name = "llvm.fmuladd";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone(), typ.clone(), typ.clone()];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_specialized_arith_intrinsics(&mut self) {
+        self.fmuladd();
+    }
+}
+
+/// The definition of the [half-precision floating-point intrinsics](https://llvm.org/docs/LangRef.html#half-precision-floating-point-intrinsics).
+impl PolyfillMap {
+    fn llvm_convert_to_f16(&mut self) {
+        let base_name = "llvm.convert.to.fp16";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[typ.clone()];
+            let return_type = LLVMType::f16;
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn llvm_convert_from_i16(&mut self) {
+        let base_name = "llvm.convert.from.fp16";
+        for typ in Self::float_types() {
+            let name = format!("{base_name}.{}", &typ);
+            let arg_types = &[LLVMType::f16];
+            let return_type = typ.clone();
+            let op = LLVMOperation::of(&name, arg_types, return_type);
+
+            let polyfill_name = Self::polyfill_name(base_name, arg_types);
+
+            self.mapping.insert(op, polyfill_name);
+        }
+    }
+
+    fn all_hp_float_intrinsics(&mut self) {
+        self.llvm_convert_to_f16();
+        self.llvm_convert_from_i16();
+    }
+}
+
+/// The definition of the [saturating floating point to integer conversions](https://llvm.org/docs/LangRef.html#saturating-floating-point-to-integer-conversions).
+impl PolyfillMap {
+    fn sat_conversion(&mut self, name: &str) {
+        let base_name = format!("llvm.{name}.sat");
+        for target_type in Self::integer_types() {
+            for source_type in Self::float_types() {
+                let name = format!("{base_name}.{}.{}", &target_type, &source_type);
+                let arg_types = &[source_type.clone()];
+                let return_type = target_type.clone();
+                let op = LLVMOperation::of(&name, arg_types, return_type);
+
+                let polyfill_name = Self::polyfill_name(&base_name, arg_types);
+
+                self.mapping.insert(op, polyfill_name);
+            }
+        }
+    }
+
+    fn all_sat_fptoi_conversions(&mut self) {
+        self.sat_conversion("fptoui");
+        self.sat_conversion("fptosi");
+    }
+}
+
+/// Useful static functions for dealing with polyfills.
+impl PolyfillMap {
+    pub fn mk(&mut self, name: &str, params: &[LLVMType], ret: LLVMType) {
+        self.mapping.insert(
+            LLVMOperation::of(name, params, ret),
+            Self::polyfill_name(name, params),
+        );
+    }
+
+    pub fn mk_dyn_ret(&mut self, name: &str, params: &[LLVMType]) {
+        self.mapping.insert(
+            LLVMOperation::of_dyn_ret(name, params),
+            Self::polyfill_name(name, params),
+        );
+    }
+
+    /// Generates the name for a polyfill for the provided `func_name` called
+    /// with the provided `types`.
     #[must_use]
-    pub fn polyfill(&self, llvm_name: &str) -> Option<&String> {
-        self.mapping.get_by_left(llvm_name)
-    }
-
-    /// Queries for the polyfill name that corresponds to the provided
-    /// `llvm_name`, returning it if it exists or returning an error otherwise.
-    ///
-    /// # Errors
-    ///
-    /// - [`Error::MissingPolyfill`] if the requested polyfill does not exist.
-    pub fn polyfill_or_err(&self, llvm_name: &str) -> Result<&String> {
-        self.polyfill(llvm_name).ok_or(Error::missing_polyfill(llvm_name))
-    }
-
-    /// Queries for the polyfill name that corresponds to the provided
-    /// `llvm_name`, returning it if it exists.
-    ///
-    /// # Panics
-    ///
-    /// If no polyfill exists for the provided `llvm_name`.
-    #[must_use]
-    pub fn expect_polyfill(&self, llvm_name: &str) -> &String {
-        self.polyfill(llvm_name)
-            .unwrap_or_else(|| panic!("{llvm_name} polyfill was not present"))
-    }
-
-    /// Queries for the LLVM opcode (as modified by [`Self::of_opcode`]) that
-    /// corresponds to the provided `polyfill_name`, returning it if it exists
-    /// or returning [`None`] otherwise.
-    #[must_use]
-    pub fn llvm(&self, polyfill_name: &str) -> Option<&String> {
-        self.mapping.get_by_right(polyfill_name)
-    }
-
-    /// Queries for the LLVM opcode (as modified by [`Self::of_opcode`]) that
-    /// corresponds to the provided `polyfill_name`, returning it if it exists
-    /// or returning an error otherwise.
-    ///
-    /// # Errors
-    ///
-    /// - [`Error::MissingPolyfill`] if the requested polyfill does not exist.
-    pub fn llvm_or_err(&self, polyfill_name: &str) -> Result<&String> {
-        self.llvm(polyfill_name).ok_or(Error::missing_polyfill(polyfill_name))
-    }
-
-    /// Queries for the LLVM opcode (as modified by [`Self::of_opcode`]) that
-    /// corresponds to the provided `polyfill_name`, returning it if it exists.
-    ///
-    /// # Panics
-    ///
-    /// If no llvm name exists for the provided `polyfill_name`.
-    #[must_use]
-    pub fn expect_llvm(&self, polyfill_name: &str) -> &String {
-        self.llvm(polyfill_name)
-            .unwrap_or_else(|| panic!("{polyfill_name} llvm definition was not present"))
-    }
-
-    /// Provides more information to assist in resolving the correct polyfill
-    /// based on the types associated with the particular opcode invocation.
-    ///
-    /// Note that this is a purely _syntactic_ transformation, and does not
-    /// account for type aliases and the like. Please ensure that any types are
-    /// fully resolved before calling this.
-    ///
-    /// ```
-    /// use hieratika_compiler::polyfill::PolyfillMap;
-    ///
-    /// let opcode_name = "add";
-    /// let arg_types = vec!["i8", "i64"];
-    ///
-    /// assert_eq!(
-    ///     PolyfillMap::of_opcode(opcode_name, arg_types.as_slice()),
-    ///     "__llvm_add_i8_i64"
-    /// );
-    /// ```
-    #[must_use]
-    pub fn of_opcode(opcode: &str, types: &[&str]) -> String {
+    pub fn polyfill_name(func_name: &str, types: &[LLVMType]) -> String {
         let types_str = if types.is_empty() {
             "void".to_string()
         } else {
-            types.join("_")
+            types.iter().map(std::string::ToString::to_string).join("_")
         };
-        format!("__llvm_{opcode}_{types_str}")
+
+        let func_name_no_dots = func_name.replace('.', "_").replace("llvm_", "");
+
+        format!("__llvm_{func_name_no_dots}_{types_str}")
+    }
+
+    /// Gets the types that we want to generate integer operations over.
+    #[must_use]
+    pub fn integer_types() -> Vec<LLVMType> {
+        // i128 intentionally omitted for now
+        vec![
+            LLVMType::bool,
+            LLVMType::i8,
+            LLVMType::i16,
+            LLVMType::i32,
+            LLVMType::i64,
+        ]
+    }
+
+    /// Gets the types that we want to generate floating-point operations over.
+    #[must_use]
+    pub fn float_types() -> Vec<LLVMType> {
+        vec![LLVMType::f16, LLVMType::f32, LLVMType::f64]
+    }
+
+    /// Gets all the numeric types that we want to potentially generate
+    /// operations over.
+    #[must_use]
+    pub fn numeric_types() -> Vec<LLVMType> {
+        let mut int_types = Self::integer_types();
+        int_types.extend(Self::float_types());
+
+        int_types
+    }
+
+    /// Gets all the integer types as well as the pointer type.
+    #[must_use]
+    pub fn intptr_types() -> Vec<LLVMType> {
+        let mut int_types = Self::integer_types();
+        int_types.push(LLVMType::ptr);
+        int_types
+    }
+
+    /// Gets all the numeric types as well as the pointer type.
+    #[must_use]
+    pub fn numptr_types() -> Vec<LLVMType> {
+        let mut num_types = Self::numeric_types();
+        num_types.push(LLVMType::ptr);
+        num_types
     }
 }
 
 impl Default for PolyfillMap {
-    /// Contains the default mapping from opcodes and builtins to the
-    /// corresponding polyfill names.
     fn default() -> Self {
-        let defaults = [
-            LLVM_ALLOCA,
-            LLVM_FENCE,
-            LLVM_STORE,
-            LLVM_UADD_WITH_OVERFLOW_I64,
-        ];
-
-        Self::new(
-            defaults
-                .into_iter()
-                .map(|(l, r)| (l.to_string(), r.to_string()))
-                .collect(),
-        )
+        Self::new()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::polyfill::PolyfillMap;
-
-    #[test]
-    fn llvm_lookup_works() {
-        let map = PolyfillMap::default();
-
-        assert_eq!(
-            map.llvm("__llvm_uadd_with_overflow_i64_i64").unwrap(),
-            "llvm.uadd.with.overflow.i64"
-        );
-    }
+    use crate::{llvm::typesystem::LLVMType, polyfill::PolyfillMap};
 
     #[test]
     fn polyfill_lookup_works() {
-        let map = PolyfillMap::default();
-
-        assert_eq!(
-            map.polyfill("llvm.uadd.with.overflow.i64").unwrap(),
-            "__llvm_uadd_with_overflow_i64_i64"
+        let map = PolyfillMap::new();
+        let polyfill = map.polyfill(
+            "llvm.uadd.with.overflow.i64",
+            &[LLVMType::i64, LLVMType::i64],
+            Some(&LLVMType::make_struct(
+                false,
+                &[LLVMType::i64, LLVMType::bool],
+            )),
         );
+
+        assert!(polyfill.is_some());
+        let name = polyfill.unwrap();
+
+        assert_eq!(name, "__llvm_uadd_with_overflow_i64_i64");
     }
 
     #[test]
-    fn of_opcode_works() {
-        let opcode_name = "my_opcode";
-        let tys_1 = vec!["i8", "i64"];
-        let tys_2 = vec!["i1"];
-        let tys_3 = vec![];
-
-        assert_eq!(
-            PolyfillMap::of_opcode(opcode_name, tys_1.as_slice()),
-            "__llvm_my_opcode_i8_i64"
-        );
-        assert_eq!(
-            PolyfillMap::of_opcode(opcode_name, tys_2.as_slice()),
-            "__llvm_my_opcode_i1"
-        );
-        assert_eq!(
-            PolyfillMap::of_opcode(opcode_name, tys_3.as_slice()),
-            "__llvm_my_opcode_void"
-        );
+    fn has_correct_polyfill_count() {
+        let polyfills = PolyfillMap::new();
+        let count = polyfills.iter().count();
+        assert_eq!(count, 842);
     }
 }

--- a/crates/compiler/tests/compilation_basic_opcodes.rs
+++ b/crates/compiler/tests/compilation_basic_opcodes.rs
@@ -1,0 +1,13 @@
+//! Tests compilation of the `opcodes.ll` IR file to check that we generate the
+//! expected FLO output.
+
+mod common;
+
+#[test]
+fn compiles_basic_opcodes() -> anyhow::Result<()> {
+    // We start by constructing and running the compiler
+    let compiler = common::default_compiler_from_path("input/opcodes.ll")?;
+    let _flo = compiler.run()?;
+
+    Ok(())
+}


### PR DESCRIPTION
# Summary

This commit also includes a re-work of how the polyfill name mapping is handled to make it easier to maintain and more robust against changes.

# Details

The usual, please.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
