### PR TITLE
Implement compilation of additional opcodes

### DIFF
--- a/crates/compiler/input/opcodes.ll
+++ b/crates/compiler/input/opcodes.ll
@@ -212,3 +212,138 @@ bb3:
   %1 = phi i8 [0, %bb1], [10, %bb2]
   ret i8 %1
 }
+
+define i1 @hieratika_test_fcmp(float %left, float %right) unnamed_addr {
+start:
+  %0 = fcmp false float %left, %right
+  %1 = fcmp oeq float %left, %right
+  %2 = fcmp ogt float %left, %right
+  %3 = fcmp oge float %left, %right
+  %4 = fcmp olt float %left, %right
+  %5 = fcmp ole float %left, %right
+  %6 = fcmp one float %left, %right
+  %7 = fcmp ord float %left, %right
+  %8 = fcmp ueq float %left, %right
+  %9 = fcmp ugt float %left, %right
+  %10 = fcmp uge float %left, %right
+  %11 = fcmp ult float %left, %right
+  %12 = fcmp ule float %left, %right
+  %13 = fcmp une float %left, %right
+  %14 = fcmp uno float %left, %right
+  %15 = fcmp true float %left, %right
+  ret i1 %15
+}
+
+define i1 @hieratika_test_icmp(i64 %left, i64 %right) unnamed_addr {
+start:
+  %0 = icmp eq i64 %left, %right
+  %1 = icmp ne i64 %left, %right
+  %2 = icmp ugt i64 %left, %right
+  %3 = icmp uge i64 %left, %right
+  %4 = icmp ult i64 %left, %right
+  %5 = icmp ule i64 %left, %right
+  %6 = icmp sgt i64 %left, %right
+  %7 = icmp sge i64 %left, %right
+  %8 = icmp slt i64 %left, %right
+  %9 = icmp sle i64 %left, %right
+  ret i1 %9
+}
+
+define double @hieratika_test_bitcast(i64 %source) unnamed_addr {
+start:
+  %0 = bitcast i64 %source to double
+  ret double %0
+}
+
+define i64 @hieratika_test_select(i1 %branch) unnamed_addr {
+start:
+  %0 = select i1 %branch, i64 0, i64 100
+  ret i64 %0
+}
+
+define void @hieratika_test_atomicrmw(ptr %ptr) unnamed_addr {
+start:
+  %0 = atomicrmw xchg ptr %ptr, i64 0 acq_rel
+  %1 = atomicrmw add ptr %ptr, i64 0 acq_rel
+  %2 = atomicrmw sub ptr %ptr, i64 0 acq_rel
+  %3 = atomicrmw and ptr %ptr, i64 0 acq_rel
+  %4 = atomicrmw nand ptr %ptr, i64 0 acq_rel
+  %5 = atomicrmw or ptr %ptr, i64 0 acq_rel
+  %6 = atomicrmw xor ptr %ptr, i64 0 acq_rel
+  %7 = atomicrmw max ptr %ptr, i64 0 acq_rel
+  %8 = atomicrmw min ptr %ptr, i64 0 acq_rel
+  %9 = atomicrmw umax ptr %ptr, i64 0 acq_rel
+  %10 = atomicrmw umin ptr %ptr, i64 0 acq_rel
+  %11 = atomicrmw fadd ptr %ptr, double 0.0 acq_rel
+  %12 = atomicrmw fsub ptr %ptr, double 0.0 acq_rel
+  %13 = atomicrmw fmax ptr %ptr, double 0.0 acq_rel
+  %14 = atomicrmw fmin ptr %ptr, double 0.0 acq_rel
+  ret void
+}
+
+define void @hieratika_test_cmpxchg(ptr %ptr) unnamed_addr {
+start:
+  %0 = cmpxchg ptr %ptr, i64 1, i64 2 acquire acquire
+  ret void
+}
+
+define {i64, {i8, i1}} @hieratika_test_load(ptr %ptr) unnamed_addr {
+start:
+  %1 = load i64, ptr %ptr
+  %2 = load {i64, {i8, i1}}, ptr %ptr
+  %3 = load [5 x [5 x i8]], ptr %ptr
+  ret {i64, {i8, i1}} %2
+}
+
+define void @hieratika_test_store(ptr %ptr, [2 x [2 x i8]] %v1, {i64, {i8, i1}} %v2) unnamed_addr {
+start:
+  store i64 0, ptr %ptr
+  store [2 x [2 x i8]] %v1, ptr %ptr
+  store {i64, {i8, i1}} %v2, ptr %ptr
+
+  ret void
+}
+
+define i8 @hieratika_test_gep(ptr %ptr, i64 %array_idx) unnamed_addr {
+start:
+  ; Implicitly dereferences the pointer %ptr at offset 0 to yield `[10 x [5 x i8]]`. Then gets the
+  ; 6th element of that array `v1 : [5 x i8]`. Then gets the 5th element of `v1` to yield `v2 : i8`.
+  ; Then returns `*v2`.
+  %tmp = getelementptr [10 x [5 x i8]], ptr %ptr, i64 0, i64 5, i64 4
+
+  ; Implicitly dereferences the pointer %ptr at offset 1 to yield `{i64, [5 x {i8, i1}]}`. Then gets
+  ; the 2nd element in the structure `v1 : [5 x {i8, i1}]`. Then gets the %array_idx-th element in
+  ; `v1` to yield `v2 : {i8, i1}`. Then gets the 1st element in `v2` to yield `v3 : i8`. Then
+  ; returns `*v3`.
+  %tmp2 = getelementptr {i64, [5 x {i8, i1}]}, ptr %ptr, i64 1, i32 1, i64 %array_idx, i32 0
+
+  ; Implicitly dereferences the pointer %ptr at offset %array_idx to yield `{i64, {i8, i1}}`. Then
+  ; gets the 2nd element in the struct `v1 : {i8, i1}`. Then gets the 1st element in `v1` to yield
+  ; `v2 : i8`. Then returns `*v2`.
+  %elem_ptr = getelementptr {i64, {i8, i1}}, ptr %ptr, i64 %array_idx, i32 1, i32 0
+  %elem_val = load i8, ptr %elem_ptr
+  ret i8 %elem_val
+}
+
+define i16 @hieratika_test_extractvalue({i64, i32, {i16, i8}} %struct_val, [5 x [5 x i16]] %array_val) unnamed_addr {
+start:
+  ; We extract the {i16, i8} as the 3rd element of the struct, and then get the first element (the `i16` of it).
+  %from_struct = extractvalue {i64, i32, {i16, i8}} %struct_val, 2, 0
+
+  ; We extract the 3rd element of the outer array (of type [5 x i16]) and then the 5th element from that array.
+  %from_array = extractvalue [5 x [5 x i16]] %array_val, 2, 4
+
+  %res = add i16 %from_struct, %from_array
+  ret i16 %res
+}
+
+define void @hieratika_test_insertvalue({i64, i32, {i16, i8}} %struct_val, [5 x [5 x i16]] %array_val) unnamed_addr {
+start:
+  ; We insert the i16 value 1 into the i16 portion of the nested struct.
+  %into_struct = insertvalue {i64, i32, {i16, i8}} %struct_val, i16 1, 2, 0
+
+  ; We insert the i16 value 10 into the 4th element of the 1st element in the array.
+  %into_array = insertvalue [5 x [5 x i16]] %array_val, i16 10, 0, 3
+
+  ret void
+}

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -108,6 +108,7 @@
 pub mod constant;
 pub mod context;
 pub mod llvm;
+pub mod messages;
 pub mod obj_gen;
 pub mod pass;
 pub mod polyfill;

--- a/crates/compiler/src/messages.rs
+++ b/crates/compiler/src/messages.rs
@@ -1,0 +1,75 @@
+//! A series of commonly-used messages in errors, both as constants and as
+//! builder functions where necessary.
+
+use hieratika_errors::compile::llvm::Error;
+use inkwell::values::{InstructionOpcode, InstructionValue};
+
+use crate::llvm::typesystem::LLVMType;
+
+/// An error message for use when expecting that an instruction had a name.
+pub const INSTRUCTION_NAMED: &str =
+    "Instruction was not named, but all non-terminator instructions should be";
+
+/// Asserts that the provided `instruction` is an instruction of the `expected`
+/// opcode.
+///
+/// # Panics
+///
+/// If the opcode associated with the provided `instruction` is not the
+/// `expected` opcode.
+pub fn assert_correct_opcode(instruction: &InstructionValue, expected: InstructionOpcode) {
+    let actual = instruction.get_opcode();
+    assert_eq!(
+        actual, expected,
+        "{expected:?} instruction expected but found {actual:?} instead"
+    );
+}
+
+/// Generates an [`Error::MalformedLLVM`] with a message about the number of
+/// operands being incorrect for the instruction.
+#[must_use]
+pub fn operand_count_error(instruction: &InstructionValue, expected: u32) -> Error {
+    let actual_arg_count = instruction.get_num_operands();
+    let opcode = instruction.get_opcode();
+    Error::MalformedLLVM(format!(
+        "{opcode:?} instruction had {actual_arg_count} operands where {expected} were expected"
+    ))
+}
+
+/// Generates an [`Error::MalformedLLVM`] with a message about required indices
+/// being missing.
+#[must_use]
+pub fn missing_indices_error(instruction: &InstructionValue) -> Error {
+    let opcode = instruction.get_opcode();
+    Error::MalformedLLVM(format!(
+        "{opcode:?} instruction had no indices, but indices are required"
+    ))
+}
+
+/// Generates an [`Error::MalformedLLVM`] with a message about the provided
+/// `instruction` only operating over aggregates but a value of type `found` was
+/// discovered instead.
+#[must_use]
+pub fn only_on_aggregates_error(instruction: &InstructionValue, found: &LLVMType) -> Error {
+    let opcode = instruction.get_opcode();
+    Error::MalformedLLVM(format!(
+        "The {opcode:?} instruction only operates on aggregates but was called on {found} instead"
+    ))
+}
+
+/// Generates an [`Error::MalformedLLVM`] with a message saying that a value of
+/// the provided `typ` claimed to be constant but had no constant value.
+#[must_use]
+pub fn non_constant_constant_error(typ: &LLVMType) -> Error {
+    Error::MalformedLLVM(format!(
+        "A value of type {typ} claimed to be constant but had no constant value"
+    ))
+}
+
+/// Generates an [`Error::MalformedLLVM`] with a message
+#[must_use]
+pub fn non_const_gep_index_error(typ: &LLVMType) -> Error {
+    Error::MalformedLLVM(format!(
+        "A GEP index with type {typ} was expected to be a constant integer but was not"
+    ))
+}

--- a/crates/compiler/tests/compilation_basic_add.rs
+++ b/crates/compiler/tests/compilation_basic_add.rs
@@ -28,8 +28,8 @@ fn compiles_add() -> anyhow::Result<()> {
     let (_, hieratika_rust_test_input) =
         flo.blocks.iter().find(|(_, b)| b.signature.is_some()).unwrap();
 
-    // It should have 11 statements in its body
-    assert_eq!(hieratika_rust_test_input.statements.len(), 11);
+    // It should have 13 statements in its body
+    assert_eq!(hieratika_rust_test_input.statements.len(), 13);
 
     // It should also end with a conditional branch instruction, which in FLO looks
     // like a match.

--- a/crates/compiler/tests/compilation_basic_opcodes.rs
+++ b/crates/compiler/tests/compilation_basic_opcodes.rs
@@ -7,7 +7,23 @@ mod common;
 fn compiles_basic_opcodes() -> anyhow::Result<()> {
     // We start by constructing and running the compiler
     let compiler = common::default_compiler_from_path("input/opcodes.ll")?;
-    let _flo = compiler.run()?;
+    let flo = compiler.run()?;
 
+    // The number of blocks should be 47 at a _minimum_, as that is the number that
+    // appears in the source file. We will definitely should not have allocated more
+    // than 100 total, however.
+    let num_blocks = flo.blocks.iter().count();
+    assert!(num_blocks >= 47);
+    assert!(num_blocks < 100);
+
+    // We should see a _minimum_ of 43 functions, as that is the number that appears
+    // in the source file. However, the construction of the Phi and Select opcodes
+    // will have resulted in the allocation of two additional ones.
+    let num_functions = flo.blocks.iter().filter(|(_, b)| b.signature.is_some()).count();
+    assert_eq!(num_functions, 45);
+
+    // Unfortunately this file is sufficiently cluttered that there is little sense
+    // in poking at this all that much more, so we just treat the above as some
+    // minor sanity checks.
     Ok(())
 }

--- a/crates/flo/src/builders.rs
+++ b/crates/flo/src/builders.rs
@@ -23,6 +23,7 @@ use crate::{
         MatchArmId,
         MemoryOrdering,
         PoisonType,
+        ReinterpretBitsStatement,
         Signature,
         SnapStatement,
         Statement,
@@ -788,6 +789,79 @@ impl<'a> BlockBuilder<'a> {
     /// - If any of the included IDs don't exist in the FLO context
     pub fn simple_desnap_into_new_variable(&mut self, snap: VariableId) -> VariableId {
         self.desnap_into_new_variable(snap, vec![], None)
+    }
+
+    /// Adds a statement that reinterprets the bits of the type `T1` of one
+    /// variable into a new type `T2` in another variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_var` - The SSA variable of type `T1` to be transmuted.
+    /// * `target_var` - The SSA variable of type `T2` to have the transmuted
+    ///   data 'written' to.
+    pub fn reinterpret_bits(
+        &mut self,
+        source_var: VariableId,
+        target_var: VariableId,
+        diagnostics: Vec<DiagnosticId>,
+        location: Option<LocationId>,
+    ) -> StatementId {
+        let stmt = ReinterpretBitsStatement {
+            source_var,
+            target_var,
+            diagnostics,
+            location,
+        };
+
+        self.add_statement(&Statement::ReinterpretBits(stmt))
+    }
+
+    /// Adds a statement that reinterprets the bits of the type `T1` of one
+    /// variable into a new type `T2` and binds it to a new variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_var` - The SSA variable of type `T1` to be transmuted.
+    pub fn reinterpret_bits_into_new_variable(
+        &mut self,
+        source_var: VariableId,
+        target_type: Type,
+        diagnostics: Vec<DiagnosticId>,
+        location: Option<LocationId>,
+    ) -> VariableId {
+        let target_var = self.add_variable(target_type);
+        self.reinterpret_bits(source_var, target_var, diagnostics, location);
+        target_var
+    }
+
+    /// Adds a statement that reinterprets the bits of the type `T1` of one
+    /// variable into a new type `T2` in another variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_var` - The SSA variable of type `T1` to be transmuted.
+    /// * `target_var` - The SSA variable of type `T2` to have the transmuted
+    ///   data 'written' to.
+    pub fn simple_reinterpret_bits(
+        &mut self,
+        source_var: VariableId,
+        target_var: VariableId,
+    ) -> StatementId {
+        self.reinterpret_bits(source_var, target_var, vec![], None)
+    }
+
+    /// Adds a statement that reinterprets the bits of the type `T1` of one
+    /// variable into a new type `T2` and binds it to a new variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_var` - The SSA variable of type `T1` to be transmuted.
+    pub fn simple_reinterpret_bits_into_new_variable(
+        &mut self,
+        source_var: VariableId,
+        target_type: Type,
+    ) -> VariableId {
+        self.reinterpret_bits_into_new_variable(source_var, target_type, vec![], None)
     }
 }
 

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -144,7 +144,7 @@ pub enum BlockExit {
 /// The types mirror [those in LLVM](https://llvm.org/docs/LangRef.html#atomic-memory-ordering-constraints)
 /// and the documentation on each variant is a reproduction of that from the
 /// LLVM language reference.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub enum MemoryOrdering {
     /// The set of values that can be read is governed by the happens-before
     /// partial order. A value cannot be read unless some operation wrote it.
@@ -225,6 +225,11 @@ pub enum Statement {
     /// "Derferences" a Snapshot, binding a new variable to the value captured
     /// at snapshot time.
     Desnap(DesnapStatement),
+
+    /// An operation that takes a variable `source_var` of type `T1`, and
+    /// performs a semantic conversion of the data's type to be `T2`, outputting
+    /// the result in the `target_var`.
+    ReinterpretBits(ReinterpretBitsStatement),
 
     /// For internal use -- indicates that this Statement is poisoned.
     Poisoned(PoisonType),
@@ -339,6 +344,28 @@ pub struct DesnapStatement {
     /// The variable to be 'populated' with the value of the snapshotted
     /// variable, at the time of its snapshotting.
     pub target: VariableId,
+
+    /// Any diagnostics associated with this statement.
+    pub diagnostics: Vec<DiagnosticId>,
+
+    /// The source location associated with this statement, if available.
+    pub location: Option<LocationId>,
+}
+
+/// An operation that takes a variable `source_var` of type `T1`, and
+/// performs a semantic conversion of the data's type to be `T2`, outputting
+/// the result in the `target_var`.
+///
+/// Note that the data in the variable **does not change**; all the bits
+/// remain the same. This is purely a conversion of how the data is
+/// interpreted.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
+pub struct ReinterpretBitsStatement {
+    /// The variable of the initial type T1 that is converted from.
+    pub source_var: VariableId,
+
+    /// The variable of the target type T2 that is converted to.
+    pub target_var: VariableId,
 
     /// Any diagnostics associated with this statement.
     pub diagnostics: Vec<DiagnosticId>,


### PR DESCRIPTION
# Summary

This implements the remaining instruction opcodes that are not terminator instructions, ensuring that we have complete coverage of all non-terminator operations.

# Details

GitHub is being strange, so trying a new PR with the same content as #98.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
