### PR TITLE
Upgraded rust toolchain to `v1.83.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["compiler", "starknet", "starkware"]
 categories = ["compilers", "virtualization", "cryptography::cryptocurrencies"]
 
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.83.0"
 
 # Dependencies that are used by more than one crate are specified here, allowing us to ensure that
 # we match versions in all crates.

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
         fenixLib = fenix.packages.${system};
-        toolchainHash = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+        toolchainHash = "sha256-s1RPtyvDGJaX/BisLT+ifVfuhDT1nZkZ1NcK8sbwELM=";
         fenixStable = fenixLib.fromToolchainName {
             name = rustVersion;
             sha256 = toolchainHash;


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
Upgraded Rust toolchain from `v1.81.0` to `v1.83.0` which is the current stable version.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [ ] Code is formatted by Rustfmt or `scarb fmt`.
- [ ] Documentation has been updated if necessary.
