### PR TITLE
Support LLVM 19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "ariadne"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
+checksum = "31beedec3ce83ae6da3a79592b3d8d7afd146a5b15bb9bb940279aced60faa89"
 dependencies = [
  "unicode-width",
  "yansi",
@@ -437,7 +437,7 @@ dependencies = [
  "rust-analyzer-salsa",
  "semver",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -509,7 +509,7 @@ dependencies = [
  "itertools 0.12.1",
  "rust-analyzer-salsa",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
 ]
 
@@ -607,7 +607,7 @@ dependencies = [
  "cairo-lang-utils",
  "cairo-vm",
  "itertools 0.12.1",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ dependencies = [
  "sha2",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -699,7 +699,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -790,7 +790,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1479,7 +1479,7 @@ dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-lowering",
  "inkwell",
- "thiserror",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1587,22 +1587,20 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 [[package]]
 name = "inkwell"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb405537710d51f6bdbc8471365ddd4cd6d3a3c3ad6e0c8291691031ba94b2"
+source = "git+https://github.com/stevefan1999-personal/inkwell?rev=0c1e5dd52cf3e012cb238ecfbdb3b1731b987c03#0c1e5dd52cf3e012cb238ecfbdb3b1731b987c03"
 dependencies = [
  "either",
  "inkwell_internals",
  "libc",
  "llvm-sys",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "inkwell_internals"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
+source = "git+https://github.com/stevefan1999-personal/inkwell?rev=0c1e5dd52cf3e012cb238ecfbdb3b1731b987c03#0c1e5dd52cf3e012cb238ecfbdb3b1731b987c03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1795,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "llvm-sys"
-version = "180.0.0"
+version = "191.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
+checksum = "893cddf1adf0354b93411e413553dd4daf5c43195d73f1acfa1e394bdd371456"
 dependencies = [
  "anyhow",
  "cc",
@@ -2360,7 +2358,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2836,7 +2834,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+dependencies = [
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -2844,6 +2851,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2985,7 +3003,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rust-version = "1.83.0"
 # we match versions in all crates.
 [workspace.dependencies]
 anyhow = "1.0.89"
-ariadne = "0.4.1"
+ariadne = "0.5.0"
 bimap = { version = "0.6.3", features = ["serde"] }
 cairo-lang-compiler = { path = "cairo/crates/cairo-lang-compiler" }
 cairo-lang-diagnostics = { path = "cairo/crates/cairo-lang-diagnostics" }
@@ -44,7 +44,9 @@ cairo-lang-sierra-generator = { path = "cairo/crates/cairo-lang-sierra-generator
 cairo-lang-utils = { path = "cairo/crates/cairo-lang-utils" }
 clap = { version = "4.5.16", features = ["derive", "cargo", "env"] }
 ethnum = "1.5.0"
-inkwell = { version = "0.5.0", features = ["llvm18-0"] }
+inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0c1e5dd52cf3e012cb238ecfbdb3b1731b987c03", features = [
+  "llvm19-0",
+] }
 itertools = "0.13.0"
 hieratika-cairoc = { path = "crates/cairoc" }
 hieratika-cli = { path = "crates/cli" }
@@ -54,7 +56,7 @@ hieratika-errors = { path = "crates/error" }
 hieratika-flo = { path = "crates/flo" }
 hieratika-test-utils = { path = "crates/test-utils" }
 starknet-types-core = "0.1.7"
-thiserror = "1.0.63"
+thiserror = "2.0.8"
 tracing = "0.1.40"
 
 [profile.release]

--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -15,6 +15,7 @@ use inkwell::{
         FunctionType,
         IntType,
         PointerType,
+        ScalableVectorType,
         StructType,
         VectorType,
         VoidType,
@@ -317,6 +318,7 @@ impl<'ctx> TryFrom<&AnyTypeEnum<'ctx>> for LLVMType {
             AnyTypeEnum::StructType(struct_type) => Self::try_from(struct_type),
             AnyTypeEnum::VoidType(void_type) => Self::try_from(void_type),
             AnyTypeEnum::VectorType(vector_type) => Self::try_from(vector_type),
+            AnyTypeEnum::ScalableVectorType(vector_type) => Self::try_from(vector_type),
         }
     }
 }
@@ -342,6 +344,7 @@ impl<'ctx> TryFrom<&BasicTypeEnum<'ctx>> for LLVMType {
             BasicTypeEnum::PointerType(ptr_type) => Self::try_from(ptr_type),
             BasicTypeEnum::StructType(struct_type) => Self::try_from(struct_type),
             BasicTypeEnum::VectorType(vector_type) => Self::try_from(vector_type),
+            BasicTypeEnum::ScalableVectorType(vector_type) => Self::try_from(vector_type),
         }
     }
 }
@@ -490,6 +493,34 @@ impl<'ctx> TryFrom<&VectorType<'ctx>> for LLVMType {
 
     fn try_from(value: &VectorType<'ctx>) -> Result<Self, Self::Error> {
         Err(Error::UnsupportedType(value.to_string()))?
+    }
+}
+
+/// Conversion from Inkwell's scalable vector type to our type language.
+///
+/// Currently, our type language **cannot represent** the scalable vector types,
+/// so this operation will error. It exists to ensure that in the future we can
+/// seamlessly add support without having to change multiple conversion sites
+/// that would currently need to produce errors.
+impl<'ctx> TryFrom<ScalableVectorType<'ctx>> for LLVMType {
+    type Error = llvm::Error;
+
+    fn try_from(value: ScalableVectorType<'ctx>) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+/// Conversion from Inkwell's scalable vector type to our type language.
+///
+/// Currently, our type language **cannot represent** the scalable vector types,
+/// so this operation will error. It exists to ensure that in the future we can
+/// seamlessly add support without having to change multiple conversion sites
+/// that would currently need to produce errors.
+impl<'ctx> TryFrom<&ScalableVectorType<'ctx>> for LLVMType {
+    type Error = llvm::Error;
+
+    fn try_from(value: &ScalableVectorType<'ctx>) -> Result<Self, Self::Error> {
+        Err(Error::UnsupportedType(value.to_string()))
     }
 }
 

--- a/crates/compiler/src/obj_gen/mod.rs
+++ b/crates/compiler/src/obj_gen/mod.rs
@@ -1758,21 +1758,23 @@ impl ObjectGenerator {
 
         // We need to start by finding out which of the possible operations this is.
         let atomic_op = match unsafe { LLVMGetAtomicRMWBinOp(instruction.as_value_ref()) } {
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXchg => "xchg",
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAdd => "add",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpSub => "sub",
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAnd => "and",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpNand => "nand",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpOr => "or",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXor => "xor",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMax => "max",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMin => "min",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMax => "umax",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMin => "umin",
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFAdd => "fadd",
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFSub => "fsub",
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMax => "fmax",
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMin => "fmin",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFSub => "fsub",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMax => "max",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMin => "min",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpNand => "nand",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpOr => "or",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpSub => "sub",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUDecWrap => "udec_wrap",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUIncWrap => "uinc_wrap",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMax => "umax",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMin => "umin",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXchg => "xchg",
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXor => "xor",
         };
         let name_header = format!("atomicrmw_{atomic_op}");
 

--- a/crates/compiler/src/obj_gen/util.rs
+++ b/crates/compiler/src/obj_gen/util.rs
@@ -165,9 +165,9 @@ pub fn get_var_or_const(
             BasicValueEnum::StructValue(_) => {
                 unimplemented!("Struct value constants are not implemented (#91)")
             }
-            BasicValueEnum::VectorValue(_) => Err(Error::unsupported_type(
-                "LLVM vector types are not supported",
-            ))?,
+            BasicValueEnum::VectorValue(_) | BasicValueEnum::ScalableVectorValue(_) => Err(
+                Error::unsupported_type("LLVM vector types are not supported"),
+            )?,
         };
 
         // With the constant value obtained, we can shove it into the actual constant,
@@ -430,6 +430,9 @@ pub fn name_type_pairs_from_value_operands(
             BasicValueEnum::VectorValue(vector_val) => {
                 Err(Error::UnsupportedType(vector_val.to_string()))?
             }
+            BasicValueEnum::ScalableVectorValue(vector_val) => {
+                Err(Error::UnsupportedType(vector_val.to_string()))?
+            }
         })
         .collect()
 }
@@ -471,6 +474,7 @@ pub fn name_from_bv(value: BasicValueEnum) -> Result<Option<String>> {
         BasicValueEnum::FloatValue(float_val) => float_val.get_name().to_str()?.to_string(),
         BasicValueEnum::StructValue(struct_val) => struct_val.get_name().to_str()?.to_string(),
         BasicValueEnum::VectorValue(vec_val) => vec_val.get_name().to_str()?.to_string(),
+        BasicValueEnum::ScalableVectorValue(vec_val) => vec_val.get_name().to_str()?.to_string(),
     };
 
     Ok(if name.is_empty() { None } else { Some(name) })

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
 
         # The default dev shell puts you in your native shell to make things feel happy.
         devShells.default = craneLib.devShell {
-          LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
+          LLVM_SYS_191_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_19.libllvm}";
           inputsFrom = lib.attrValues hieratika;
           packages = devshellPackages;
 
@@ -133,14 +133,14 @@
 
           shellHook = ''
             mkdir -p "$rustTestInputsDest"
-            cp -rv "$rustTestInputs"/* "$rustTestInputsDest"
+            cp -r "$rustTestInputs"/* "$rustTestInputsDest"
 
             exec $(${getUserShellCommand})
           '';
         };
 
         devShells.unstable = craneLibUnstable.devShell {
-          LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
+          LLVM_SYS_191_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_19.libllvm}";
           inputsFrom = lib.attrValues hieratikaUnstable;
           packages = devshellPackages;
           shellHook = ''
@@ -150,7 +150,7 @@
 
         # The dev shell for CI allows it to interpret commands properly.
         devShells.ci = craneLib.devShell {
-          LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
+          LLVM_SYS_191_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_19.libllvm}";
           inputsFrom = lib.attrValues hieratika;
           packages = devshellPackages;
         };

--- a/workspace.nix
+++ b/workspace.nix
@@ -10,7 +10,7 @@
   bzip2,
   libiconv,
   libxml2,
-  llvmPackages_18,
+  llvmPackages_19,
 }:
  let
   workspaceToml = lib.importTOML ./Cargo.toml;
@@ -37,14 +37,14 @@
 
     # Things that are needed at build time on the system doing building.
     nativeBuildInputs = [
-      llvmPackages_18.llvm
+      llvmPackages_19.llvm
     ];
 
     # The things that we need available at build and runtime on the target system.
     buildInputs = [
       libffi
       libxml2
-      llvmPackages_18.llvm
+      llvmPackages_19.llvm
     ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
       bzip2
       libiconv


### PR DESCRIPTION
# Summary

This commit bumps our Inkwell dependency to depend on a WIP branch that adds support for LLVM 19 but without support for any of the new features that 19 comes with. This means that the version in the nix configuration is also changed.

This is done in order to support compiling to LLVM IR with the latest nightlies, which use LLVM 19 and have the most up-to-date `build-std` support.

# Details

Just a check that nothing has been changed _except_ the LLVM version. All of the tests pass as is, of course.

Work to move to the official Inkwell repo is tracked in #117. 

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
