### PR TITLE
Test the compiler on `core` and `alloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ariadne"
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -613,7 +613,7 @@ version = "2.9.2"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -993,7 +993,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1150,28 +1150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "unicode-xid",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -1318,9 +1296,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "funty"
@@ -1347,7 +1325,7 @@ checksum = "43eaff6bbc0b3a878361aced5ec6a2818ee7c541c5b33b5880dfa9a86c23e9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1394,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97630e1e456d7081c524488a87d8f8f7ed0fd3100ba10c55e3cfa7add5ce05c6"
+checksum = "10efcd6c7d6f84cb5b4f9155248e0675deab9cfb92d0edbcb25cb81490b65ae7"
 dependencies = [
  "fnv",
  "microlp",
@@ -1497,17 +1475,15 @@ dependencies = [
  "anyhow",
  "bimap",
  "chumsky",
- "clap",
- "derive_more",
  "downcast-rs",
  "ethnum",
  "hieratika-errors",
  "hieratika-flo",
  "inkwell",
  "itertools 0.13.0",
+ "miette",
  "ouroboros",
  "rand",
- "tracing",
 ]
 
 [[package]]
@@ -1530,7 +1506,7 @@ dependencies = [
  "inkwell",
  "itertools 0.13.0",
  "miette",
- "thiserror 2.0.8",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -1598,7 +1574,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1655,7 +1631,7 @@ source = "git+https://github.com/stevefan1999-personal/inkwell?rev=0c1e5dd52cf3e
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1834,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -1911,9 +1887,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "microlp"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0c5664f9959f1c3970d523a22f0319024282cb754358c2afc7e1d45280ae3"
+checksum = "8113ec0619201ef0ead05ecafe9ba59b525ab73508456b8d35dbaf810cd07704"
 dependencies = [
  "log",
  "sprs",
@@ -1947,7 +1923,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2127,7 +2103,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2253,9 +2229,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -2301,9 +2277,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2315,15 +2291,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2365,7 +2341,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "version_check",
  "yansi",
 ]
@@ -2381,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2547,7 +2523,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2596,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2637,7 +2613,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2657,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -2676,13 +2652,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2693,14 +2669,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -2841,7 +2817,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2945,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2983,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -3008,11 +2984,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.8",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -3023,18 +2999,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3138,7 +3114,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3263,7 +3239,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -3285,7 +3261,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3402,9 +3378,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -3457,7 +3433,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3477,7 +3453,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -16,16 +16,14 @@ rust-version.workspace = true
 [dependencies]
 bimap.workspace = true
 chumsky = "0.9.3"
-clap.workspace = true
-derive_more = { version = "1.0.0", features = ["full"] }
 downcast-rs = "1.2.1"
 ethnum.workspace = true
 inkwell.workspace = true
 itertools.workspace = true
 hieratika-errors.workspace = true
 hieratika-flo.workspace = true
+miette.workspace = true
 ouroboros = "0.18.4"
-tracing.workspace = true
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/crates/compiler/input/compilation/add.ll
+++ b/crates/compiler/input/compilation/add.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '9ox3ykpp0gbrqxqlz7ajwa9w6'
 source_filename = "9ox3ykpp0gbrqxqlz7ajwa9w6"
-target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-target triple = "aarch64-unknown-none"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
 
 @alloc_4190527422e5cc48a15bd1cb4f38f425 = private unnamed_addr constant <{ [33 x i8] }> <{ [33 x i8] c"crates/rust-test-input/src/lib.rs" }>, align 1
 @alloc_5b4544c775a23c08ca70c48dd7be27fc = private unnamed_addr constant <{ ptr, [16 x i8] }> <{ ptr @alloc_4190527422e5cc48a15bd1cb4f38f425, [16 x i8] c"!\00\00\00\00\00\00\00\05\00\00\00\05\00\00\00" }>, align 8

--- a/crates/compiler/input/compilation/bad_data_layout.ll
+++ b/crates/compiler/input/compilation/bad_data_layout.ll
@@ -1,0 +1,10 @@
+; ModuleID = 'opcodes.ll'
+source_filename = "opcodes.ll"
+target datalayout = "E-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+define i64 @hieratika_test_add(i64 %left, i64 %right) unnamed_addr {
+start:
+  %0 = add nuw nsw i64 %left, %right
+  ret i64 %0
+}

--- a/crates/compiler/input/compilation/bad_target_triple.ll
+++ b/crates/compiler/input/compilation/bad_target_triple.ll
@@ -1,0 +1,10 @@
+; ModuleID = 'opcodes.ll'
+source_filename = "opcodes.ll"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64"
+
+define i64 @hieratika_test_add(i64 %left, i64 %right) unnamed_addr {
+start:
+  %0 = add nuw nsw i64 %left, %right
+  ret i64 %0
+}

--- a/crates/compiler/input/compilation/constants.ll
+++ b/crates/compiler/input/compilation/constants.ll
@@ -1,0 +1,55 @@
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+@test_const = constant { i1, [9 x i8] } { i1 0, [9 x i8] c"hieratika" }
+
+; @constant_pointer_const = constant ptr @test_const
+; @constant_pointer_const_in_struct = constant { i1, ptr } { i1 0, ptr @test_const }
+
+; @function_pointer_const = constant ptr @hieratika_test_const_integer
+; @function_pointer_const_in_struct = constant { i1, ptr } { i1 0, ptr @hieratika_test_const_integer }
+
+define ptr @hieratika_test_reference_const() unnamed_addr {
+start:
+  ret ptr @test_const
+}
+
+define i64 @hieratika_test_const_integer() unnamed_addr {
+start:
+  ret i64 0
+}
+
+define double @hieratika_test_const_float() unnamed_addr {
+start:
+  ret double 0.0
+}
+
+define void @hieratika_test_const_pointer() unnamed_addr {
+start:
+  %addr = alloca ptr
+  store ptr blockaddress(@hieratika_test_const_pointer, %bb1), ptr %addr
+  ret void
+bb1:
+  unreachable
+}
+
+define void @hieratika_test_const_array() unnamed_addr {
+start:
+  %ptr = alloca ptr
+  store [2 x i8] [i8 0, i8 1], ptr %ptr
+  ret void
+}
+
+define void @hieratika_test_const_string() unnamed_addr {
+start:
+  %ptr = alloca ptr
+  store [9 x i8] c"hieratika", ptr %ptr
+  ret void
+}
+
+define void @hieratika_test_const_struct() unnamed_addr {
+start:
+  %ptr = alloca ptr
+  store { i8, i1 } { i8 0, i1 1 }, ptr %ptr
+  ret void
+}

--- a/crates/compiler/input/compilation/opcodes.ll
+++ b/crates/compiler/input/compilation/opcodes.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'opcodes.ll'
 source_filename = "opcodes.ll"
-target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-target triple = "aarch64-unknown-none"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
 
 ; Arithmetic and logic operations
 

--- a/crates/compiler/input/compilation/terminators.ll
+++ b/crates/compiler/input/compilation/terminators.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'opcodes.ll'
 source_filename = "opcodes.ll"
-target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-target triple = "aarch64-unknown-none"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
 
 ; Supported terminator instructions
 

--- a/crates/compiler/src/constant.rs
+++ b/crates/compiler/src/constant.rs
@@ -1,5 +1,13 @@
 //! Useful constants for use within the compiler.
 
+/// The expected target triple for our platform, intended to be used for
+/// validation during compilation.
+pub const TARGET_TRIPLE: &str = "riscv64";
+
+/// The expected data layout for our platform, intended to be used for
+/// validation during compilation.
+pub const TARGET_DATA_LAYOUT: &str = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128";
+
 /// The size of a byte on our architecture.
 pub const BYTE_SIZE_BITS: usize = 8;
 

--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -58,6 +58,9 @@ pub enum LLVMType {
     /// The 16-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
     i16,
 
+    /// The 24-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
+    i24,
+
     /// The 32-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
     i32,
 
@@ -156,6 +159,8 @@ impl LLVMType {
             self,
             Self::bool
                 | Self::i8
+                | Self::i16
+                | Self::i24
                 | Self::i32
                 | Self::i64
                 | Self::i128
@@ -224,6 +229,7 @@ impl LLVMType {
             f64,
             i8,
             i16,
+            i24,
             i32,
             i64,
             i128,
@@ -231,7 +237,7 @@ impl LLVMType {
             void,
         };
         match self {
-            bool | i8 | i16 | i32 | i64 | i128 | f16 | f32 | f64 | ptr => 1,
+            bool | i8 | i16 | i24 | i32 | i64 | i128 | f16 | f32 | f64 | ptr => 1,
             void | Metadata => 0,
             Array(array_ty) => array_ty.size_of(),
             Structure(struct_ty) => struct_ty.size_of(),
@@ -258,6 +264,7 @@ impl Display for LLVMType {
             LLVMType::bool => "i1".to_string(),
             LLVMType::i8 => "i8".to_string(),
             LLVMType::i16 => "i16".to_string(),
+            LLVMType::i24 => "i24".to_string(),
             LLVMType::i32 => "i32".to_string(),
             LLVMType::i64 => "i64".to_string(),
             LLVMType::i128 => "i128".to_string(),
@@ -412,6 +419,7 @@ impl<'ctx> TryFrom<&IntType<'ctx>> for LLVMType {
             1 => Self::bool,
             8 => Self::i8,
             16 => Self::i16,
+            24 => Self::i24,
             32 => Self::i32,
             64 => Self::i64,
             128 => Self::i128,

--- a/crates/compiler/src/obj_gen/data.rs
+++ b/crates/compiler/src/obj_gen/data.rs
@@ -169,6 +169,7 @@ impl ObjectContext {
             LLVMType::bool => Type::Bool,
             LLVMType::i8 => Type::Signed8,
             LLVMType::i16 => Type::Signed16,
+            LLVMType::i24 => Type::Signed24,
             LLVMType::i32 => Type::Signed32,
             LLVMType::i64 => Type::Signed64,
             LLVMType::i128 => Type::Signed128,

--- a/crates/compiler/src/pass/analysis/module_map.rs
+++ b/crates/compiler/src/pass/analysis/module_map.rs
@@ -496,8 +496,7 @@ mod test {
         // The data layout should have been picked up correctly from the module, and we
         // know that parsing works, so we check equality
         let data_layout = &map.data_layout;
-        let expected_data_layout =
-            DataLayout::new("e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128")?;
+        let expected_data_layout = DataLayout::new("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128")?;
         assert_eq!(data_layout, &expected_data_layout);
 
         Ok(())

--- a/crates/compiler/src/polyfill.rs
+++ b/crates/compiler/src/polyfill.rs
@@ -1181,6 +1181,7 @@ impl PolyfillMap {
             LLVMType::bool,
             LLVMType::i8,
             LLVMType::i16,
+            LLVMType::i24,
             LLVMType::i32,
             LLVMType::i64,
             LLVMType::i128,
@@ -1249,6 +1250,6 @@ mod test {
     fn has_correct_polyfill_count() {
         let polyfills = PolyfillMap::new();
         let count = polyfills.iter().count();
-        assert_eq!(count, 970);
+        assert_eq!(count, 1103);
     }
 }

--- a/crates/compiler/tests/bug_111.rs
+++ b/crates/compiler/tests/bug_111.rs
@@ -4,8 +4,9 @@
 mod common;
 
 #[test]
-fn accepts_anonymous_function_argument_names() -> anyhow::Result<()> {
+fn accepts_anonymous_function_argument_names() -> miette::Result<()> {
     // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
     let compiler = common::default_compiler_from_path("input/bug/bug-111.ll")?;
     let flo = compiler.run()?;
 

--- a/crates/compiler/tests/common/mod.rs
+++ b/crates/compiler/tests/common/mod.rs
@@ -1,10 +1,19 @@
 //! Common utilities for the integration tests, these are intended to make it
 //! easier to write complex tests of the compiler's functionality.
 
-use std::path::Path;
+// Ensures that we can import this common module into tests without getting warnings for every
+// function we do not use.
+#![allow(dead_code)]
+
+use std::{collections::HashMap, path::Path};
 
 use hieratika_compiler::{Compiler, CompilerBuilder, context::SourceContext};
-use hieratika_flo::FlatLoweredObject;
+use hieratika_flo::{
+    FlatLoweredObject,
+    types::{Block, FunctionSymbol},
+};
+use itertools::Itertools;
+use miette::MietteHandlerOpts;
 
 /// Creates a compiler—with default settings for passes and polyfills—wrapping
 /// the module at the provided `path`.
@@ -14,14 +23,40 @@ use hieratika_flo::FlatLoweredObject;
 /// - [`anyhow::Error`] if the path does not exist.
 /// - [`ltc_errors::compiler::Error`] if the compiler cannot load the file at
 ///   `path` as LLVM IR.
-pub fn default_compiler_from_path(path: &str) -> anyhow::Result<Compiler> {
+pub fn default_compiler_from_path(path: &str) -> miette::Result<Compiler> {
     let path = Path::new(path);
     let ctx = SourceContext::create(path)?;
 
     Ok(CompilerBuilder::new(ctx).build())
 }
 
+/// Gets all functions in the provided `flo`.
+///
+/// Note that this operates based on the symbol table, and will not discover
+/// functions not inserted into said table.
+pub fn get_functions(flo: &FlatLoweredObject) -> HashMap<FunctionSymbol, Block> {
+    let syms_and_blocks = flo.symbols.code.iter().map(|(s, i)| (s.clone(), *i)).collect_vec();
+    syms_and_blocks
+        .into_iter()
+        .map(|(s, i)| (s, flo.blocks.get(i)))
+        .collect()
+}
+
 /// Counts the number of functions found in the provided `flo`.
+///
+/// Note that this works from the _symbol table_, and will not detect functions
+/// not inserted into said table.
 pub fn count_functions(flo: &FlatLoweredObject) -> usize {
-    flo.blocks.iter().filter(|(_, b)| b.signature.is_some()).count()
+    get_functions(flo).len()
+}
+
+/// Sets default reporting options for Miette in tests.
+///
+/// This should be called at the start of each of the compiler tests.
+pub fn set_miette_reporting() -> miette::Result<()> {
+    miette::set_hook(Box::new(|_| {
+        Box::new(MietteHandlerOpts::new().width(200).build())
+    }))?;
+
+    Ok(())
 }

--- a/crates/compiler/tests/compilation_alloc.rs
+++ b/crates/compiler/tests/compilation_alloc.rs
@@ -1,0 +1,16 @@
+//! Tests compilation of `alloc.ll` the Rust core allocation library.
+
+mod common;
+
+#[test]
+fn compiles_alloc() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
+    let compiler = common::default_compiler_from_path("input/compilation/alloc.ll")?;
+    let _flo = compiler.run();
+
+    // There should be a single function in the context.
+    // assert_eq!(common::count_functions(&flo), 1);
+
+    Ok(())
+}

--- a/crates/compiler/tests/compilation_constants.rs
+++ b/crates/compiler/tests/compilation_constants.rs
@@ -1,0 +1,14 @@
+//! Tests compilation of various kinds of constant initializer expressions in
+//! the LLVM IR input.
+
+mod common;
+
+#[test]
+fn compiles_constants() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
+    let compiler = common::default_compiler_from_path("input/compilation/constants.ll")?;
+    let _flo = compiler.run()?;
+
+    Ok(())
+}

--- a/crates/compiler/tests/compilation_opcodes.rs
+++ b/crates/compiler/tests/compilation_opcodes.rs
@@ -4,8 +4,9 @@
 mod common;
 
 #[test]
-fn compiles_basic_opcodes() -> anyhow::Result<()> {
+fn compiles_basic_opcodes() -> miette::Result<()> {
     // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
     let compiler = common::default_compiler_from_path("input/compilation/opcodes.ll")?;
     let flo = compiler.run()?;
 
@@ -16,11 +17,10 @@ fn compiles_basic_opcodes() -> anyhow::Result<()> {
     assert!(num_blocks >= 47);
     assert!(num_blocks < 100);
 
-    // We should see a _minimum_ of 43 functions, as that is the number that appears
-    // in the source file. However, the construction of the Phi and Select opcodes
-    // will have resulted in the allocation of two additional ones.
+    // We should see 43 functions, as that is the number that appears in the source
+    // file.
     let num_functions = common::count_functions(&flo);
-    assert_eq!(num_functions, 45);
+    assert_eq!(num_functions, 43);
 
     // Unfortunately this file is sufficiently cluttered that there is little sense
     // in poking at this all that much more, so we just treat the above as some

--- a/crates/compiler/tests/compilation_terminators.rs
+++ b/crates/compiler/tests/compilation_terminators.rs
@@ -4,8 +4,9 @@
 mod common;
 
 #[test]
-fn compiles_terminator_instructions() -> anyhow::Result<()> {
+fn compiles_terminator_instructions() -> miette::Result<()> {
     // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
     let compiler = common::default_compiler_from_path("input/compilation/terminators.ll")?;
     let flo = compiler.run()?;
 

--- a/crates/compiler/tests/invalid_target.rs
+++ b/crates/compiler/tests/invalid_target.rs
@@ -1,0 +1,36 @@
+//! Tests that the compiler rejects inputs that have invalid target
+//! specifications, both in terms of the target triple and the data layout.
+
+use hieratika_errors::compile::llvm::Error;
+
+mod common;
+
+#[test]
+fn rejects_invalid_data_layout() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    let compiler = common::default_compiler_from_path("input/compilation/bad_data_layout.ll")?;
+    let err = compiler.run();
+
+    assert!(err.is_err());
+    assert!(matches!(
+        err.unwrap_err().source,
+        Error::IncompatibleDataLayout(_, _)
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_target_triple() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    let compiler = common::default_compiler_from_path("input/compilation/bad_target_triple.ll")?;
+    let err = compiler.run();
+
+    assert!(err.is_err());
+    assert!(matches!(
+        err.unwrap_err().source,
+        Error::IncompatibleTargetSpecification(_, _)
+    ));
+
+    Ok(())
+}

--- a/crates/error/src/compile/llvm.rs
+++ b/crates/error/src/compile/llvm.rs
@@ -29,6 +29,16 @@ pub enum Error {
     #[error("Could not create Rust string from C string: {_0}")]
     CStrConversionError(#[from] Utf8Error),
 
+    /// Emitted when the compilation process encounters an incompatible data
+    /// layout specification in the module being compiled.
+    #[error("The provided data layout {_0} is not compatible with {_1}")]
+    IncompatibleDataLayout(String, String),
+
+    /// Emitted when the compilation process encounters an incompatible target
+    /// machine specification in the module being compiled.
+    #[error("The provided target specification {_0} is not compatible with {_1}")]
+    IncompatibleTargetSpecification(String, String),
+
     #[error("`{_0}` with invalid segment `{_1}` could not be parsed as an LLVM data layout")]
     InvalidDataLayoutSpecification(String, String),
 

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -512,6 +512,7 @@ pub enum Type {
     Unsigned128,
     Signed8,
     Signed16,
+    Signed24,
     Signed32,
     Signed64,
     Signed128,


### PR DESCRIPTION
# Summary

This commit uses the previously-compiled LLVM IR representations of the rust `core`, `alloc` and `compiler_builtins` libraries to test the functionality of the hieratika compiler. At the same time it fixes any bugs that are found through this process.

It also enables the compiler to consistency check the target definition in the file being compiled against the expected target definition, ensuring that it does not do unnecessary work on unsupported inputs.

It also implements functionality for working with constants of aggregate type, thereby closing #91.

# Details

Please pay careful attention to the logical changes.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
