### PR TITLE
Comply with the new memory model

### DIFF
--- a/crates/compiler/src/messages.rs
+++ b/crates/compiler/src/messages.rs
@@ -10,6 +10,14 @@ use crate::llvm::typesystem::LLVMType;
 pub const INSTRUCTION_NAMED: &str =
     "Instruction was not named, but all non-terminator instructions should be";
 
+/// An error message for use when expecting that the module mapping pass exists.
+pub const MISSING_MODULE_MAP: &str =
+    "No data was available for the module mapping pass, but is required";
+
+/// An error message for use when expecting that a struct type has at least one
+/// element.
+pub const STRUCT_TYPE_WITH_NO_MEMBERS: &str = "Struct type had no members but must have at least 1";
+
 /// Asserts that the provided `instruction` is an instruction of the `expected`
 /// opcode.
 ///

--- a/crates/compiler/src/polyfill.rs
+++ b/crates/compiler/src/polyfill.rs
@@ -386,15 +386,18 @@ impl PolyfillMap {
 
 /// The definition of the [memory access and addressing operations](https://llvm.org/docs/LangRef.html#memory-access-and-addressing-operations).
 impl PolyfillMap {
+    /// This is the platform-level allocator.
+    fn alloc(&mut self) {
+        // The first argument is the size of the allocation in bits, while the second
+        // argument is the number of instances of that size to allocate.
+        self.mk("alloc", &[LLVMType::i64, LLVMType::i64], LLVMType::ptr);
+    }
+
     fn alloca(&mut self) {
-        // The first argument is the size, in felts, of the allocation, while the second
+        // The first argument is the size of the allocation in bits, while the second
         // argument is the number of instances of that size to allocate.
         self.mk("alloca", &[LLVMType::i64, LLVMType::i64], LLVMType::ptr);
     }
-
-    // TODO composites via iteration. load_* for each prim type, taking an offset
-    // from the ptr and the ptr. Need to fix insertvalue and extractvalue. Use
-    // construct and destructure to deal with these things.
 
     fn load(&mut self) {
         // Due to the nature of the types available in FLO, we can only load and store
@@ -402,7 +405,7 @@ impl PolyfillMap {
         // type, and we have to decompose loads and stores of aggregates into loads and
         // stores using primitive types.
 
-        // Our load function takes the pointer to load and an offset (in felts) from
+        // Our load function takes the pointer to load and an offset in bits from
         // that pointer, and returns the result of loading from that pointer.
         for typ in Self::numptr_types() {
             self.mk("load", &[LLVMType::ptr, LLVMType::i64], typ);
@@ -416,7 +419,7 @@ impl PolyfillMap {
         // stores using primitive types.
 
         // Our store function takes the value to store, the pointer to store it at, and
-        // an offset (in felts) from that pointer at which the primitive value should be
+        // an offset in bits from that pointer at which the primitive value should be
         // stored.
         for typ in Self::numptr_types() {
             self.mk(
@@ -487,6 +490,7 @@ impl PolyfillMap {
     }
 
     fn all_memory_ops(&mut self) {
+        self.alloc();
         self.alloca();
         self.load();
         self.store();
@@ -1250,6 +1254,6 @@ mod test {
     fn has_correct_polyfill_count() {
         let polyfills = PolyfillMap::new();
         let count = polyfills.iter().count();
-        assert_eq!(count, 1103);
+        assert_eq!(count, 1104);
     }
 }


### PR DESCRIPTION
# Summary

Unfortunately our memory model has had to change in order to support the kinds of type punning that we see in the output of `rustc`. What this primarily means is that we have changed to a byte-addressable model, reducing overall memory usage on the Cairo VM at the cost of more computation steps.

Each machine word fits 28 bytes, along with 28 bits worth of flags for future use by the memory subsystem. These flags are not treated as part of contiguous memory.

The primary changes are:

- A swap to calculate both `size_of` and `align_of` in bytes in the LLVM type system used by the compiler. This relies on the specified data layout for accurate computation.
- Alterations to the semantics of the memory-related polyfills and opcodes to compute offsets and sizes properly using the new machinery for doing so.

This commit also includes documentation of the new memory model.

# Details

Please sanity check my calculations!

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
