### PR TITLE
Make some initial fixes get `core` compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,9 @@ tracing = "0.1.40"
 debug = true           # Include full debug information in release builds.
 overflow-checks = true # Keep overflow checks in production builds.
 lto = "thin"           # Thin LTO performs cheaper cross-crate LTO.
+
+# Running the compiler tests in a reasonable time means we need to optimize,
+# but we also want to retain debug assertions and debug information.
+[profile.test]
+opt-level = 1
+debug = "full"

--- a/crates/compiler/input/compilation/phi.ll
+++ b/crates/compiler/input/compilation/phi.ll
@@ -1,0 +1,26 @@
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+; We declare the necessary functions and constants to avoid unavailable references
+@alloc_e547e50f836b5d080f631e710773931f = private unnamed_addr constant <{ ptr, [16 x i8] }> <{ ptr @alloc_e951d9caa9b0332887c975fc323e279a, [16 x i8] c"j\00\00\00\00\00\00\00\9D\01\00\00-\00\00\00" }>, align 8
+@alloc_e951d9caa9b0332887c975fc323e279a = private unnamed_addr constant <{ [106 x i8] }> <{ [106 x i8] c"/nix/store/hahzrgjq3ncgd241r37xm63ydm9xxfp7-rust-mixed/lib/rustlib/src/rust/library/core/src/array/iter.rs" }>, align 1
+@7 = private unnamed_addr constant <{ [4 x i8] }> undef, align 4
+
+declare i64 @_ZN4core3ops11index_range10IndexRange3end17h736da45717d9393bE(ptr align 8 %new)
+declare { i64, i64 } @_ZN4core3ops11index_range10IndexRange7zero_to17h9efe20b9ab4c8a42E(i64 %0)
+
+; <core::array::iter::IntoIter<T,_> as core::clone::Clone>::clone
+; Function Attrs: noredzone nounwind
+define dso_local void @"_ZN79_$LT$core..array..iter..IntoIter$LT$T$C$_$GT$$u20$as$u20$core..clone..Clone$GT$5clone17h19b6a6ce98691d0aE"(ptr sret([32 x i8]) align 8 %_0, ptr align 8 %self) unnamed_addr {
+start:
+  %_10 = alloca [16 x i8], align 8
+  br label %repeat_loop_header
+
+repeat_loop_header:                               ; preds = %repeat_loop_body, %start
+  %1 = phi i64 [ 0, %start ], [ %4, %repeat_loop_body ]
+  br i1 0, label %repeat_loop_body, label %repeat_loop_header
+
+repeat_loop_body:                                 ; preds = %repeat_loop_header
+  %4 = add nuw i64 %1, 1
+  br label %repeat_loop_header
+}

--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -73,6 +73,12 @@ pub enum LLVMType {
     /// The 32-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
     i32,
 
+    /// The 40-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
+    i40,
+
+    /// The 48-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
+    i48,
+
     /// The 64-bit wide [integer type](https://llvm.org/docs/LangRef.html#integer-type).
     i64,
 
@@ -171,6 +177,8 @@ impl LLVMType {
                 | Self::i16
                 | Self::i24
                 | Self::i32
+                | Self::i40
+                | Self::i48
                 | Self::i64
                 | Self::i128
                 | Self::f16
@@ -234,6 +242,8 @@ impl LLVMType {
             LLVMType::i16 => 16,
             LLVMType::i24 => 24,
             LLVMType::i32 => 32,
+            LLVMType::i40 => 40,
+            LLVMType::i48 => 48,
             LLVMType::i64 => 64,
             LLVMType::i128 => 128,
             LLVMType::f16 => 16,
@@ -278,32 +288,40 @@ impl LLVMType {
     pub fn align_of(&self, align_type: AlignType, data_layout: &DataLayout) -> usize {
         match self {
             LLVMType::bool => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(1).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(1).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(1).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(1).preferred_alignment,
             },
             LLVMType::i8 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(8).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(8).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(8).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(8).preferred_alignment,
             },
             LLVMType::i16 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(16).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(16).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(16).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(16).preferred_alignment,
             },
             LLVMType::i24 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(24).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(24).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(24).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(24).preferred_alignment,
             },
             LLVMType::i32 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(32).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(32).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(32).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(32).preferred_alignment,
+            },
+            LLVMType::i40 => match align_type {
+                AlignType::ABI => data_layout.int_spec_of(40).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(40).preferred_alignment,
+            },
+            LLVMType::i48 => match align_type {
+                AlignType::ABI => data_layout.int_spec_of(48).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(48).preferred_alignment,
             },
             LLVMType::i64 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(64).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(64).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(64).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(64).preferred_alignment,
             },
             LLVMType::i128 => match align_type {
-                AlignType::ABI => data_layout.expect_int_spec_of(128).abi_alignment,
-                AlignType::Preferred => data_layout.expect_int_spec_of(128).preferred_alignment,
+                AlignType::ABI => data_layout.int_spec_of(128).abi_alignment,
+                AlignType::Preferred => data_layout.int_spec_of(128).preferred_alignment,
             },
             LLVMType::f16 => match align_type {
                 AlignType::ABI => data_layout.expect_float_spec_of(16).abi_alignment,
@@ -343,6 +361,8 @@ impl Display for LLVMType {
             LLVMType::i16 => "i16".to_string(),
             LLVMType::i24 => "i24".to_string(),
             LLVMType::i32 => "i32".to_string(),
+            LLVMType::i40 => "i40".to_string(),
+            LLVMType::i48 => "i48".to_string(),
             LLVMType::i64 => "i64".to_string(),
             LLVMType::i128 => "i128".to_string(),
             LLVMType::f16 => "f16".to_string(),
@@ -479,6 +499,8 @@ impl<'ctx> TryFrom<&IntType<'ctx>> for LLVMType {
             16 => Self::i16,
             24 => Self::i24,
             32 => Self::i32,
+            40 => Self::i40,
+            48 => Self::i48,
             64 => Self::i64,
             128 => Self::i128,
             _ => Err(Error::UnsupportedType(value.to_string()))?,
@@ -1134,6 +1156,18 @@ mod test {
     }
 
     #[test]
+    fn calculates_correct_size_for_i40() {
+        assert_eq!(LLVMType::i40.size_of(&dl()), 40);
+        assert_eq!(LLVMType::i40.store_size_of(&dl()), 40);
+    }
+
+    #[test]
+    fn calculates_correct_size_for_i48() {
+        assert_eq!(LLVMType::i48.size_of(&dl()), 48);
+        assert_eq!(LLVMType::i48.store_size_of(&dl()), 48);
+    }
+
+    #[test]
     fn calculates_correct_size_for_i64() {
         assert_eq!(LLVMType::i64.size_of(&dl()), 64);
         assert_eq!(LLVMType::i64.store_size_of(&dl()), 64);
@@ -1250,6 +1284,18 @@ mod test {
     fn calculates_correct_alignment_for_i32() {
         assert_eq!(LLVMType::i32.align_of(ABI, &dl()), 32);
         assert_eq!(LLVMType::i32.align_of(Preferred, &dl()), 32);
+    }
+
+    #[test]
+    fn calculates_correct_alignment_for_i40() {
+        assert_eq!(LLVMType::i40.align_of(ABI, &dl()), 64);
+        assert_eq!(LLVMType::i40.align_of(Preferred, &dl()), 64);
+    }
+
+    #[test]
+    fn calculates_correct_alignment_for_i48() {
+        assert_eq!(LLVMType::i48.align_of(ABI, &dl()), 64);
+        assert_eq!(LLVMType::i48.align_of(Preferred, &dl()), 64);
     }
 
     #[test]

--- a/crates/compiler/src/polyfill.rs
+++ b/crates/compiler/src/polyfill.rs
@@ -1187,6 +1187,8 @@ impl PolyfillMap {
             LLVMType::i16,
             LLVMType::i24,
             LLVMType::i32,
+            LLVMType::i40,
+            LLVMType::i48,
             LLVMType::i64,
             LLVMType::i128,
         ]
@@ -1254,6 +1256,6 @@ mod test {
     fn has_correct_polyfill_count() {
         let polyfills = PolyfillMap::new();
         let count = polyfills.iter().count();
-        assert_eq!(count, 1104);
+        assert_eq!(count, 1379);
     }
 }

--- a/crates/compiler/tests/compilation_alloc.rs
+++ b/crates/compiler/tests/compilation_alloc.rs
@@ -7,8 +7,6 @@ fn compiles_alloc() -> miette::Result<()> {
     // We start by constructing and running the compiler
     common::set_miette_reporting()?;
 
-    // Currently known to fail due to missing features and bugs.
-
     let compiler = common::default_compiler_from_path("input/compilation/alloc.ll")?;
     let flo = compiler.run()?;
 

--- a/crates/compiler/tests/compilation_core.rs
+++ b/crates/compiler/tests/compilation_core.rs
@@ -1,0 +1,17 @@
+//! Tests compilation of `core.ll` the Rust core library.
+
+mod common;
+
+#[test]
+fn compiles_core() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
+
+    let compiler = common::default_compiler_from_path("input/compilation/core.ll")?;
+    let flo = compiler.run()?;
+
+    // There should be 2678 functions in the context.
+    assert_eq!(common::count_functions(&flo, false), 2678);
+
+    Ok(())
+}

--- a/crates/compiler/tests/compilation_phi.rs
+++ b/crates/compiler/tests/compilation_phi.rs
@@ -1,0 +1,18 @@
+//! Tests compilation of `phi.ll` a file exhibiting complex uses of the LLVM
+//! `phi` instruction.
+
+mod common;
+
+#[test]
+fn compiles_phi() -> miette::Result<()> {
+    // We start by constructing and running the compiler
+    common::set_miette_reporting()?;
+
+    let compiler = common::default_compiler_from_path("input/compilation/phi.ll")?;
+    let flo = compiler.run()?;
+
+    // There should be a single function in the context.
+    assert_eq!(common::count_functions(&flo, false), 1);
+
+    Ok(())
+}

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -514,6 +514,8 @@ pub enum Type {
     Signed16,
     Signed24,
     Signed32,
+    Signed40,
+    Signed48,
     Signed64,
     Signed128,
 

--- a/crates/mangler/src/mapping.rs
+++ b/crates/mangler/src/mapping.rs
@@ -88,6 +88,8 @@ pub fn mangle_type(typ: &Type) -> Result<String> {
         Type::Signed16 => "h",
         Type::Signed24 => "x",
         Type::Signed32 => "i",
+        Type::Signed40 => "n",
+        Type::Signed48 => "k",
         Type::Signed64 => "q",
         Type::Signed128 => "o",
         Type::WeaklyTypedFelt => "w",


### PR DESCRIPTION
# Summary

This commit is a grab-bag of smaller fixes required to get Rust's `core` library compiling properly by hieratika. They include:

- Adding support for an `i48` type which seems to be required, as well as adding polyfill stubs for such a type.
- Adding support for an `i40` type which seems to be required, as well as adding polyfill stubs for such a type.
- Changing the `DataLayout` type's query functionality to comply with the layout promotion rules for integers.
- Registers all variables inside a function ahead of time to cope with usages before declaration in lexical order but not in execution order.
- Changes the handling of GetElementPtr instructions to account for negative indices, which were not apparently allowed from the LangRef, but are encountered in `core`. As GetElementPtr does not access memory, it does make sense that they are allowed, so we now support them here.

# Details

Just the usual checks, please!

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
