### PR TITLE
Disallow redefining polyfills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "miette",
  "ouroboros",
  "rand 0.9.0",
+ "regex",
 ]
 
 [[package]]

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -29,3 +29,4 @@ rand = "0.9.0"
 
 [dev-dependencies]
 anyhow.workspace = true
+regex = "1.11.1"

--- a/crates/compiler/input/pass/declared_polyfill_bad_type.ll
+++ b/crates/compiler/input/pass/declared_polyfill_bad_type.ll
@@ -1,0 +1,7 @@
+; Functions with names that clash with polyfills should be an error if they are
+; declared with an incorrect type.
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+declare dso_local i64 @__llvm_uadd_with_overflow_l_l_Slcs(i64 %l, i64 %r)

--- a/crates/compiler/input/pass/declared_polyfill_correct_type.ll
+++ b/crates/compiler/input/pass/declared_polyfill_correct_type.ll
@@ -1,0 +1,7 @@
+; Functions with names that clash with polyfills should be allowed if they are
+; declared with the correct type.
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+declare dso_local {i64, i1} @__llvm_uadd_with_overflow_l_l_Slcs(i64 %l, i64 %r)

--- a/crates/compiler/input/pass/redefined_polyfill.ll
+++ b/crates/compiler/input/pass/redefined_polyfill.ll
@@ -1,0 +1,10 @@
+; Functions with names that clash with polyfills should result in compilation
+; failing if they are definitions.
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64"
+
+define dso_local i32 @__llvm_uadd_with_overflow_l_l_Slcs(i32 %1) {
+  %3 = mul i32 %1, %1
+  ret i32 %3
+}

--- a/crates/compiler/src/config.rs
+++ b/crates/compiler/src/config.rs
@@ -1,0 +1,20 @@
+//! The compiler's configuration, which specifies portions of the compiler's
+//! behavior at runtime.
+
+use crate::polyfill::PolyfillMap;
+
+/// The configuration for the compiler.
+#[derive(Debug)]
+pub struct CompilerConfig {
+    /// The set of polyfills to be made available in this compilation.
+    pub polyfills: PolyfillMap,
+}
+
+/// The default configuration for the compiler.
+impl Default for CompilerConfig {
+    fn default() -> Self {
+        Self {
+            polyfills: PolyfillMap::default(),
+        }
+    }
+}

--- a/crates/compiler/src/messages.rs
+++ b/crates/compiler/src/messages.rs
@@ -18,6 +18,11 @@ pub const MISSING_MODULE_MAP: &str =
 /// element.
 pub const STRUCT_TYPE_WITH_NO_MEMBERS: &str = "Struct type had no members but must have at least 1";
 
+/// An error message for when a polyfill is inadvertently replaced while
+/// constructing the polyfill mapping.
+pub const POLYFILL_REPLACED_IN_MAPPING: &str =
+    "A polyfill was replaced when constructing the polyfill mapping";
+
 /// Asserts that the provided `instruction` is an instruction of the `expected`
 /// opcode.
 ///

--- a/crates/compiler/src/pass/analysis/module_map.rs
+++ b/crates/compiler/src/pass/analysis/module_map.rs
@@ -17,6 +17,7 @@ use inkwell::{
 };
 
 use crate::{
+    CompilerConfig,
     context::SourceContext,
     llvm::{
         TopLevelEntryKind,
@@ -265,6 +266,7 @@ impl PassOps for BuildModuleMap {
         &mut self,
         context: SourceContext,
         _pass_data: &DynPassDataMap,
+        _compiler_config: &CompilerConfig,
     ) -> Result<DynPassReturnData> {
         let analysis_result = context.analyze_module(|module| self.map_module(module))?;
         Ok(DynPassReturnData::new(context, Box::new(analysis_result)))
@@ -432,6 +434,7 @@ mod test {
     use inkwell::{GlobalVisibility, module::Linkage};
 
     use crate::{
+        CompilerConfig,
         context::SourceContext,
         llvm::{
             TopLevelEntryKind,
@@ -453,6 +456,12 @@ mod test {
             .expect("Unable to construct testing source context")
     }
 
+    /// A utility function to make it easy to provide a default compiler config
+    /// for testing.
+    fn c_cfg() -> CompilerConfig {
+        CompilerConfig::default()
+    }
+
     #[test]
     fn generates_random_names_for_anon_modules() {
         let map_1 = ModuleMap::new("", DataLayout::new("").unwrap());
@@ -467,7 +476,7 @@ mod test {
         let ctx = get_test_context();
         let data = DynPassDataMap::new();
         let mut pass = BuildModuleMap::new_dyn();
-        let dyn_return_data = pass.run(ctx, &data)?;
+        let dyn_return_data = pass.run(ctx, &data, &c_cfg())?;
 
         // We should be able to get the pass data as the correct associated type.
         assert!(
@@ -487,7 +496,7 @@ mod test {
         let data = DynPassDataMap::new();
         let mut pass = BuildModuleMap::new_dyn();
 
-        let dyn_return_data = pass.run(ctx, &data)?;
+        let dyn_return_data = pass.run(ctx, &data, &c_cfg())?;
         let map = dyn_return_data
             .data
             .view_as::<<BuildModuleMap as ConcretePass>::Data>()
@@ -508,7 +517,7 @@ mod test {
         let data = DynPassDataMap::new();
         let mut pass = BuildModuleMap::new_dyn();
 
-        let dyn_return_data = pass.run(ctx, &data)?;
+        let dyn_return_data = pass.run(ctx, &data, &c_cfg())?;
         let map = dyn_return_data
             .data
             .view_as::<<BuildModuleMap as ConcretePass>::Data>()
@@ -572,7 +581,7 @@ mod test {
         let data = DynPassDataMap::new();
         let mut pass = BuildModuleMap::new_dyn();
 
-        let dyn_return_data = pass.run(ctx, &data)?;
+        let dyn_return_data = pass.run(ctx, &data, &c_cfg())?;
         let map = dyn_return_data
             .data
             .view_as::<<BuildModuleMap as ConcretePass>::Data>()

--- a/crates/compiler/src/pass/check/mod.rs
+++ b/crates/compiler/src/pass/check/mod.rs
@@ -1,0 +1,4 @@
+//! Contains passes that detect erroneous conditions in the input IR and abort
+//! compilation as a result.
+
+pub mod polyfill_redefinitions;

--- a/crates/compiler/src/pass/check/polyfill_redefinitions.rs
+++ b/crates/compiler/src/pass/check/polyfill_redefinitions.rs
@@ -1,0 +1,250 @@
+//! This pass checks—using the [`crate::pass::analysis::module_map`] pass—that
+//! no builtins/polyfills are being redefined in the current module by user
+//! code.
+//!
+//! When doing this check we purely care about the _name_ of the polyfill being
+//! redefined, as we do not want to care about potential name overloading. To
+//! this end, we do not check the user definition's type against the expected
+//! type for the polyfill. This means that an error will be raised if a name
+//! clashes regardless of type, and **this is intended behavior**.
+//!
+//! However, in the case of _declarations_, we perform a consistency check
+//! against the expected type of the polyfill to prevent the user from suffering
+//! link-time errors instead of earlier compile-time errors.
+
+use std::collections::HashSet;
+
+use hieratika_errors::compile::llvm::{Error, Result};
+use itertools::{Either, Itertools};
+
+use crate::{
+    CompilerConfig,
+    context::SourceContext,
+    llvm::{TopLevelEntryKind, typesystem::LLVMFunction},
+    pass::{
+        ConcretePass,
+        Pass,
+        PassKey,
+        PassOps,
+        analysis::module_map::BuildModuleMap,
+        data::{DynPassDataMap, DynPassReturnData, EmptyPassData},
+    },
+};
+
+/// Raises an error if it detects any redefinition of a compiler builtin or
+/// polyfill, thereby preventing users from inadvertently changing code
+/// behavior.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DisallowPolyfillRedefinitions {
+    /// The passes that this pass depends upon the results of for its execution.
+    depends: Vec<PassKey>,
+
+    /// The passes that this pass invalidates the results of by executing.
+    invalidates: Vec<PassKey>,
+}
+
+impl Default for DisallowPolyfillRedefinitions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Constructors that provide ways to create an instance of the
+/// [`DisallowPolyfillRedefinitions`] pass.
+impl DisallowPolyfillRedefinitions {
+    /// Creates a new instance of the polyfill redefinitions pass.
+    #[must_use]
+    pub fn new() -> Self {
+        // This pass requires the module mapping information to do its job.
+        let depends = vec![BuildModuleMap::key()];
+
+        // But as a consistency check it does not invalidate anything.
+        let invalidates = vec![];
+
+        Self {
+            depends,
+            invalidates,
+        }
+    }
+
+    /// Creates a new trait object of the polyfill redefinitions pass.
+    #[must_use]
+    pub fn new_dyn() -> Box<Self> {
+        Box::new(Self::new())
+    }
+}
+
+/// We implement `PassOps` for this pass to allow it to be run via the pass
+/// manager.
+impl PassOps for DisallowPolyfillRedefinitions {
+    fn run(
+        &mut self,
+        context: SourceContext,
+        pass_data: &DynPassDataMap,
+        compiler_config: &CompilerConfig,
+    ) -> Result<DynPassReturnData> {
+        let module_map = pass_data.expect::<BuildModuleMap>();
+
+        // We first get all the names and types of functions that are both defined and
+        // declared in the current module.
+        let (defined_functions, declared_functions): (Vec<_>, Vec<_>) =
+            module_map.functions.iter().partition_map(|(k, v)| match v.kind {
+                TopLevelEntryKind::Definition => Either::Left((k.as_str(), &v.typ)),
+                TopLevelEntryKind::Declaration => Either::Right((k.as_str(), &v.typ)),
+            });
+
+        // Then we get all the reserved names for the polyfills.
+        let polyfill_names = compiler_config
+            .polyfills
+            .iter()
+            .map(|(_, v)| v.as_str())
+            .collect::<HashSet<_>>();
+
+        // Then we check them for redefinition.
+        for (name, _) in defined_functions {
+            if polyfill_names.contains(name) {
+                Err(Error::RedefinedPolyfill(name.to_string()))?;
+            }
+        }
+
+        for (name, declared_type) in declared_functions {
+            if let Some(spec) = compiler_config.polyfills.get_operation_spec(name) {
+                let expected_type =
+                    LLVMFunction::new(spec.return_type.clone(), &spec.operand_types);
+
+                if &expected_type != declared_type {
+                    // If the name is a polyfill name but the provided type does not match that of
+                    // the polyfill by that name, then it is a declaration of an invalid polyfill
+                    // and should raise an error.
+                    Err(Error::InvalidPolyfillDeclaration(
+                        name.to_string(),
+                        declared_type.to_string(),
+                        expected_type.to_string(),
+                    ))?;
+                }
+            }
+        }
+
+        // If we get to this point we have encountered no redefinitions, and if all
+        // declarations are correct, we just return.
+        Ok(DynPassReturnData::new(
+            context,
+            <Self as ConcretePass>::Data::new_dyn(),
+        ))
+    }
+
+    fn depends(&self) -> &[PassKey] {
+        self.depends.as_slice()
+    }
+
+    fn invalidates(&self) -> &[PassKey] {
+        self.invalidates.as_slice()
+    }
+
+    fn dupe(&self) -> Pass {
+        Box::new(self.clone())
+    }
+}
+
+/// We also want to be able to work with the pass when it is **not** type-erased
+/// to `dyn PassOps`, so we implement this too.
+impl ConcretePass for DisallowPolyfillRedefinitions {
+    /// This pass doesn't return anything, so its data is the empty pass data.
+    type Data = EmptyPassData<Self>;
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use hieratika_errors::compile::llvm::{Error, Result};
+
+    use crate::{
+        config::CompilerConfig,
+        context::SourceContext,
+        pass::{
+            ConcretePass,
+            PassOps,
+            analysis::module_map::BuildModuleMap,
+            check::polyfill_redefinitions::DisallowPolyfillRedefinitions,
+            data::{DynPassDataMap, DynPassReturnData},
+        },
+    };
+
+    /// Prepares a context with the necessary pass data in it.
+    fn load_context(path: &str) -> Result<(SourceContext, DynPassDataMap, CompilerConfig)> {
+        let context = SourceContext::create(Path::new(path))
+            .expect("Unable to construct testing source context");
+        let mut pass_data = DynPassDataMap::new();
+        let config = CompilerConfig::default();
+
+        let DynPassReturnData {
+            source_context,
+            data,
+        } = BuildModuleMap::new_dyn().run(context, &pass_data, &config)?;
+
+        pass_data.put_key(BuildModuleMap::key(), data);
+
+        Ok((source_context, pass_data, config))
+    }
+
+    #[test]
+    fn succeeds_on_no_redefinition() -> miette::Result<()> {
+        // We start by setting up our test data
+        let (ctx, pass_data, config) = load_context(r"input/compilation/add.ll")?;
+
+        // Then we can run our pass
+        let pass_return = DisallowPolyfillRedefinitions::new_dyn().run(ctx, &pass_data, &config);
+        assert!(pass_return.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn fails_on_encountering_redefinition() -> miette::Result<()> {
+        // We start by setting up our test data
+        let (ctx, pass_data, config) = load_context(r"input/pass/redefined_polyfill.ll")?;
+
+        // Then we can run our pass
+        let pass_return = DisallowPolyfillRedefinitions::new_dyn().run(ctx, &pass_data, &config);
+        assert!(pass_return.is_err());
+        assert!(matches!(
+            pass_return.unwrap_err().source,
+            Error::RedefinedPolyfill(name) if name == "__llvm_uadd_with_overflow_l_l_Slcs"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn allows_correct_declaration_of_polyfill() -> miette::Result<()> {
+        // We start by setting up our test data
+        let (ctx, pass_data, config) =
+            load_context(r"input/pass/declared_polyfill_correct_type.ll")?;
+
+        // Then we can run our pass
+        let pass_return = DisallowPolyfillRedefinitions::new_dyn().run(ctx, &pass_data, &config);
+        assert!(pass_return.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn fails_on_incorrect_declaration_of_polyfill() -> miette::Result<()> {
+        // We start by setting up our test data
+        let (ctx, pass_data, config) = load_context(r"input/pass/declared_polyfill_bad_type.ll")?;
+
+        // Then we can run our pass
+        let pass_return = DisallowPolyfillRedefinitions::new_dyn().run(ctx, &pass_data, &config);
+        assert!(pass_return.is_err());
+        assert!(matches!(
+            pass_return.unwrap_err().source,
+            Error::InvalidPolyfillDeclaration(name, actual, expected)
+                if name == "__llvm_uadd_with_overflow_l_l_Slcs"
+                && actual == "(i64, i64) -> i64"
+                && expected == "(i64, i64) -> { i64, i1 }"
+        ));
+
+        Ok(())
+    }
+}

--- a/crates/error/src/compile/llvm.rs
+++ b/crates/error/src/compile/llvm.rs
@@ -52,6 +52,11 @@ pub enum Error {
     #[error("Invalid Pass Ordering: {_0}")]
     InvalidPassOrdering(String),
 
+    /// Emitted when user code declares a known polyfill name with an incorrect
+    /// type.
+    #[error("Polyfill {_0} declared with incorrect type {_1} where {_2} was expected")]
+    InvalidPolyfillDeclaration(String, String, String),
+
     /// Emitted when code tries to convert between types in a way that is
     /// invalid.
     #[error("Could not convert types: {_0}")]
@@ -85,6 +90,10 @@ pub enum Error {
     /// Emitted when a global value that is not `constant` is discovered.
     #[error("The global with name `{_0}` is non-constant, but we only support constant globals")]
     NonConstantGlobal(String),
+
+    /// Emitted when user code attempts to redefine a polyfill.
+    #[error("User code attempted to redefine the reserved polyfill name {_0}")]
+    RedefinedPolyfill(String),
 
     /// Emitted when a mismatch is found between types.
     #[error("{_0} != {_1} but were expected to be equal")]


### PR DESCRIPTION
# Summary

This commit adds a pass that prohibits user code from redefining polyfills. This is necessary as the actual polyfill names differ from the opcodes used in LLVM, and hence redefining them needs to be explicitly disallowed.

This is done using a check pass that runs after the module mapping pass and uses the module map to check for user-defined functions that clash with the polyfill names. Note that _declaring_ the polyfills is explicitly allowed in the case that users want to call them directly.

It also fixes a bug where multiple potential polyfills would end up with clashing names. It does this by switching the polyfill naming scheme to instead use the mangler for the types it embeds in the name. This means we can always generate valid names while also including return type information for complete disambiguation between polyfills.

Closes #135.

# Details

Just check that things make sense as ever!

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
