### PR TITLE
Added `paste` library to `deny.toml`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
   { id = "RUSTSEC-2024-0388", reason = "In our submodule dependency on Cairo, and hence out of our control" },
+  { id = "RUSTSEC-2024-0436", reason = "In our submodule dependency on Cairo, and hence out of our control" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
This change adds the `paste` library to the list of ignored warnings from `cargo deny check`.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->
The `paste` library has been marked as unmaintained, this causes the `cargo deny check` to fail. However, this library is currently used by the crate `cairo-lang-runner`, therefore it's out of our control. An exception is the best immediate way forward and a related ticket has been opened for future tracking of this.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
