### PR TITLE
compiler-rt: crt0: allocator: change Address type to u64

### DIFF
--- a/compiler-rt/src/crt0/allocator/test.cairo
+++ b/compiler-rt/src/crt0/allocator/test.cairo
@@ -1,5 +1,6 @@
-use crate::crt0::allocator::{Allocator, AllocatorOps, AllocatorState, Address, SIZEOF_CELL};
-use crate::crt0::allocator::utils;
+use crate::crt0::allocator::{
+    Allocator, AllocatorOps, AllocatorState, Address, ByteCount, SIZEOF_CELL, utils,
+};
 
 #[cfg(test)]
 mod allocate {
@@ -49,7 +50,7 @@ mod allocate {
     /// exceeding the gas limit of 4294967295. The allocation size has been discovered
     /// experimentally. This value assumes that the tests does nothing more than the instantiation
     /// of the allocator and a single allocation of that many bytes.
-    const MAX_ALLOCATION: u128 = 0x990ae4;
+    const MAX_ALLOCATION: ByteCount = 0xc4acec;
 
     #[test]
     #[available_gas(4294967295)]

--- a/compiler-rt/src/crt0/allocator/utils.cairo
+++ b/compiler-rt/src/crt0/allocator/utils.cairo
@@ -2,16 +2,16 @@
 //! Not meant to be used outside of the allocator.
 
 use core::num::traits::OverflowingMul;
-use crate::crt0::allocator::{Address, ByteCount, SIZEOF_CELL};
+use crate::crt0::allocator::{Address, ByteCount, CellCount, SIZEOF_CELL};
 
 /// Calculate base address of the cell given an arbitrary address.
-pub fn cells_base_address(address: Address) -> u128 {
+pub fn cells_base_address(address: Address) -> Address {
     address - address % SIZEOF_CELL
 }
 
 /// Calculate how many memory cells will a given amount of bytes occupy,
 /// depending on the size of the data and the address data is loaded from or stored to.
-pub fn cells_count_from_bytes(address: Address, bytes_count: ByteCount) -> u128 {
+pub fn cells_count_from_bytes(address: Address, bytes_count: ByteCount) -> CellCount {
     let is_start_on_cell_boundary = address % SIZEOF_CELL == 0;
     let is_end_on_cell_boundary = (address + bytes_count) % SIZEOF_CELL == 0;
 

--- a/docs/CRT0.md
+++ b/docs/CRT0.md
@@ -78,7 +78,8 @@ implemented and tested in Cairo.
   and the current allocations.
 
   ```rust
-  type Address = u128;
+  /// The `Address` type is `u64`, as this is the largest pointer type supported by Rust.
+  type Address = u64;
 
   struct AllocatorState {
     /// The address at which the next requested allocation will begin.
@@ -93,17 +94,6 @@ implemented and tested in Cairo.
     allocated_addresses: HashMap<Address, FeltValue>
   }
   ```
-
-- The `Address` type is decided to be `u128` for the following reasons:
-
-  - `u128` is the common largest native type of Cairo and Rust. Cairo supports `u256`, `u384` and
-    `u512`, but they're complex types, built around `struct`s.
-  - `u128` has all the necessary arithmetic operations implemented. Cairo supports `felt252`
-    natively, which is larger than `u128`, but does not implement
-    [operations that are necessary for address calculations](https://github.com/reilabs/hieratika/issues/38#issuecomment-2471249442).
-  - Addresses will be returned and accepted by polyfills. The
-    [current polyfill design](./ALU%20Design.md#Operands) assumes that all inputs and outputs are
-    `u128`, so the address type cannot be larger than that.
 
 - There is a function that allocates the indicated number of bytes and returns the address of that
   allocation.


### PR DESCRIPTION
# Summary

u128 was too large. Rust's pointers are 64-bit.

Interestingly this change increases the maximum available allocation in tests by 28,51%.

# Details

The change is pretty trivial, I just changed types aliases and added one extra so there's no bare `u64` in the code.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
