### PR TITLE
Updated function `is_integral` to include new integer types

### DIFF
--- a/crates/compiler/src/llvm/typesystem.rs
+++ b/crates/compiler/src/llvm/typesystem.rs
@@ -205,7 +205,15 @@ impl LLVMType {
     pub fn is_integral(&self) -> bool {
         matches!(
             self,
-            Self::bool | Self::i8 | Self::i16 | Self::i32 | Self::i64 | Self::i128
+            Self::bool
+                | Self::i8
+                | Self::i16
+                | Self::i24
+                | Self::i32
+                | Self::i40
+                | Self::i48
+                | Self::i64
+                | Self::i128
         )
     }
 


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
This PR updates the function `is_integral` to include additional integer types.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
