### PR TITLE
Implement the `u24` type

### DIFF
--- a/compiler-rt/src/integer.cairo
+++ b/compiler-rt/src/integer.cairo
@@ -1,1 +1,9 @@
+pub mod u24;
 pub mod u40;
+
+/// The basic operations required of our odd-width non-native integers.
+pub trait IntegerOps<T> {
+    /// Constructs a new integer value, panicking if the provided value does not
+    /// fit into the correct number of bits.
+    fn new(value: u128) -> T;
+}

--- a/compiler-rt/src/integer/u24.cairo
+++ b/compiler-rt/src/integer/u24.cairo
@@ -1,0 +1,337 @@
+use core::num::traits::{
+    BitSize, Bounded, WrappingAdd, WrappingSub, WrappingMul, OverflowingAdd, OverflowingSub,
+    OverflowingMul,
+};
+use crate::integer::IntegerOps;
+use crate::utils::assert_fits_in_type;
+
+use core::traits::{Div, Rem, BitOr, BitAnd};
+
+/// The struct to represent 24-bit integers.
+///
+/// They are stored internally using a u128, so it is important to ensure that,
+/// at every use site, the actual valure that is read and written fits within 24
+/// bits.
+#[derive(Debug, Drop, PartialEq)]
+pub struct u24 {
+    data: u128,
+}
+
+impl U24IntegerOps of IntegerOps<u24> {
+    fn new(value: u128) -> u24 {
+        assert_fits_in_type::<u24>(value);
+        u24 { data: value }
+    }
+}
+
+impl U8IntoU24 of Into<u8, u24> {
+    fn into(self: u8) -> u24 {
+        return u24 { data: self.into() };
+    }
+}
+
+impl U24TryIntoU8 of TryInto<u24, u8> {
+    fn try_into(self: u24) -> Option<u8> {
+        return self.data.try_into();
+    }
+}
+
+impl U24IntoU128 of Into<u24, u128> {
+    fn into(self: u24) -> u128 {
+        return self.data;
+    }
+}
+
+impl U128TryIntoU24 of TryInto<u128, u24> {
+    fn try_into(self: u128) -> Option<u24> {
+        let bitmask = Bounded::<u24>::MAX.into();
+        let significant_bits = self & bitmask;
+        if significant_bits != self {
+            return Option::None;
+        }
+        return Option::Some(u24 { data: self });
+    }
+}
+
+/// The implementation of the `BitSize` trait for `u24` returns 24 because it is
+/// the size of a 24 bit integer despite using 128bits of memory.
+impl U24BitSize of BitSize<u24> {
+    fn bits() -> usize {
+        24
+    }
+}
+
+impl BoundedU40 of Bounded<u24> {
+    const MIN: u24 = u24 { data: 0b0 };
+    const MAX: u24 = u24 { data: 0xFFFFFF }; // (1<<24)-1
+}
+
+impl U24WrappingAdd of WrappingAdd<u24> {
+    fn wrapping_add(self: u24, v: u24) -> u24 {
+        let (sum, _) = self.overflowing_add(v);
+        return sum;
+    }
+}
+
+impl U24OverflowingAdd of OverflowingAdd<u24> {
+    fn overflowing_add(self: u24, v: u24) -> (u24, bool) {
+        let lhs = self.data;
+        let rhs = v.data;
+        let sum = lhs + rhs;
+        let sum_sat = sum & Bounded::<u24>::MAX.into();
+        let result = u24 { data: sum_sat };
+
+        if sum_sat == sum {
+            let is_overflow = false;
+            return (result, is_overflow);
+        }
+        let is_overflow = true;
+        return (result, is_overflow);
+    }
+}
+
+impl U24WrappingSub of WrappingSub<u24> {
+    fn wrapping_sub(self: u24, v: u24) -> u24 {
+        let (diff, _) = self.overflowing_sub(v);
+        return diff;
+    }
+}
+
+impl U24OverflowingSub of OverflowingSub<u24> {
+    fn overflowing_sub(self: u24, v: u24) -> (u24, bool) {
+        let lhs = self.data;
+        let rhs = Bounded::<u24>::MAX.into() - v.data + 1;
+        let diff = (lhs + rhs);
+        let diff_sat = diff & Bounded::<u24>::MAX.into();
+        let result = u24 { data: diff_sat };
+
+        if diff_sat == diff {
+            let is_overflow = true;
+            return (result, is_overflow);
+        }
+        let is_overflow = false;
+        return (result, is_overflow);
+    }
+}
+
+impl U24WrappingMul of WrappingMul<u24> {
+    fn wrapping_mul(self: u24, v: u24) -> u24 {
+        let (product, _) = self.overflowing_mul(v);
+        return product;
+    }
+}
+
+impl U24OverflowingMul of OverflowingMul<u24> {
+    fn overflowing_mul(self: u24, v: u24) -> (u24, bool) {
+        let lhs = self.data;
+        let rhs = v.data;
+        let product = (lhs * rhs);
+        let product_sat = product % (Bounded::<u24>::MAX.into() + 1);
+        let result = u24 { data: product_sat };
+
+        if product_sat == product {
+            let is_overflow = false;
+            return (result, is_overflow);
+        }
+        let is_overflow = true;
+        return (result, is_overflow);
+    }
+}
+
+impl U24Rem of Rem<u24> {
+    fn rem(lhs: u24, rhs: u24) -> u24 {
+        let lhs = lhs.data;
+        let rhs = rhs.data;
+        let remainder = lhs % rhs;
+        return u24 { data: remainder };
+    }
+}
+
+impl U24Div of Div<u24> {
+    fn div(lhs: u24, rhs: u24) -> u24 {
+        let lhs = lhs.data;
+        let rhs = rhs.data;
+        let ratio = lhs / rhs;
+        return u24 { data: ratio };
+    }
+}
+
+impl U24BitOr of BitOr<u24> {
+    fn bitor(lhs: u24, rhs: u24) -> u24 {
+        let result = lhs.data | rhs.data;
+        u24 { data: result & Bounded::<u24>::MAX.into() }
+    }
+}
+
+impl U24BitAnd of BitAnd<u24> {
+    fn bitand(lhs: u24, rhs: u24) -> u24 {
+        let result = lhs.data & rhs.data;
+        u24 { data: result & Bounded::<u24>::MAX.into() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::u24;
+    use crate::utils::assert_fits_in_type;
+
+    use super::U24IntegerOps as U24Ops;
+
+    use core::num::traits::{
+        BitSize, WrappingAdd, WrappingSub, WrappingMul, OverflowingAdd, OverflowingSub,
+        OverflowingMul,
+    };
+    use core::traits::{Div, Rem, BitOr, BitAnd};
+
+    #[test]
+    fn test_u24() {
+        assert_eq!(U24Ops::new(0).into(), 0_u128);
+        assert_eq!(U24Ops::new(0).try_into().unwrap(), 0_u8);
+        assert_eq!(U24Ops::new(3).into(), 3_u128);
+        assert_eq!(U24Ops::new(3).try_into().unwrap(), 3_u8);
+        assert_eq!(0_u8.into(), U24Ops::new(0));
+        assert_eq!(3_u8.into(), U24Ops::new(3));
+        assert_eq!(U24Ops::new(0b111111111111111111111111).into(), 0b111111111111111111111111_u128);
+        assert_fits_in_type::<u24>(10);
+    }
+
+    #[test]
+    #[should_panic(expected: "value = 4294967295 does not fit in u24")]
+    fn u24_fails_to_construct_if_too_large() {
+        U24Ops::new(0xFFFFFFFF);
+    }
+
+    #[test]
+    fn test_size_u24() {
+        let bits = BitSize::<u24>::bits();
+        assert_eq!(bits, 24);
+    }
+
+    #[test]
+    fn test_eq_u24() {
+        let a = U24Ops::new(3);
+        let b = U24Ops::new(3);
+        assert_eq!(a, b);
+
+        let c = U24Ops::new(0);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_wrapping_add_u24() {
+        let lhs = U24Ops::new(3);
+        let rhs = U24Ops::new(8);
+        let sum = lhs.wrapping_add(rhs);
+        assert_eq!(sum.into(), 11_u128);
+
+        let lhs = U24Ops::new(0b111111111111111111111111);
+        let rhs = U24Ops::new(1);
+        let sum = lhs.wrapping_add(rhs);
+        assert_eq!(sum.into(), 0_u128);
+    }
+
+    #[test]
+    fn test_overflowing_add_u24() {
+        let lhs = U24Ops::new(3);
+        let rhs = U24Ops::new(8);
+        let (sum, is_overflow) = lhs.overflowing_add(rhs);
+        assert_eq!(sum.into(), 11_u128);
+        assert_eq!(is_overflow, false);
+
+        let lhs = U24Ops::new(0b111111111111111111111111);
+        let rhs = U24Ops::new(1);
+        let (sum, is_overflow) = lhs.overflowing_add(rhs);
+        assert_eq!(sum.into(), 0_u128);
+        assert_eq!(is_overflow, true);
+    }
+
+    #[test]
+    fn test_wrapping_sub_u24() {
+        let lhs = U24Ops::new(8);
+        let rhs = U24Ops::new(3);
+        let diff = lhs.wrapping_sub(rhs);
+        assert_eq!(diff.into(), 5_u128);
+
+        let lhs = U24Ops::new(0);
+        let rhs = U24Ops::new(1);
+        let diff = lhs.wrapping_sub(rhs);
+        assert_eq!(diff.into(), 0b111111111111111111111111_u128);
+    }
+
+    #[test]
+    fn test_overflowing_sub_u24() {
+        let lhs = U24Ops::new(8);
+        let rhs = U24Ops::new(3);
+        let (diff, is_overflow) = lhs.overflowing_sub(rhs);
+        assert_eq!(diff.into(), 5_u128);
+        assert_eq!(is_overflow, false);
+
+        let lhs = U24Ops::new(0);
+        let rhs = U24Ops::new(1);
+        let (diff, is_overflow) = lhs.overflowing_sub(rhs);
+        assert_eq!(diff.into(), 0b111111111111111111111111_u128);
+        assert_eq!(is_overflow, true);
+    }
+
+    #[test]
+    fn test_wrapping_mul_u24() {
+        let lhs = U24Ops::new(8);
+        let rhs = U24Ops::new(3);
+        let product = lhs.wrapping_mul(rhs);
+        assert_eq!(product.into(), 24_u128);
+
+        let lhs = U24Ops::new(0b111111111111111111111111);
+        let rhs = U24Ops::new(2);
+        let product = lhs.wrapping_mul(rhs);
+        assert_eq!(product.into(), 0b111111111111111111111110_u128);
+    }
+
+    #[test]
+    fn test_overflowing_mul_u24() {
+        let lhs = U24Ops::new(8);
+        let rhs = U24Ops::new(3);
+        let (product, is_overflow) = lhs.overflowing_mul(rhs);
+        assert_eq!(product.into(), 24_u128);
+        assert_eq!(is_overflow, false);
+
+        let lhs = U24Ops::new(0b111111111111111111111111);
+        let rhs = U24Ops::new(2);
+        let (product, is_overflow) = lhs.overflowing_mul(rhs);
+        assert_eq!(product.into(), 0b111111111111111111111110_u128);
+        assert_eq!(is_overflow, true);
+    }
+
+    #[test]
+    fn test_rem_u24() {
+        let lhs = U24Ops::new(8);
+        let rhs = U24Ops::new(3);
+        let remainder = Rem::rem(lhs, rhs);
+        assert_eq!(remainder.into(), 2_u128);
+    }
+
+    #[test]
+    fn test_div_u24() {
+        let lhs = U24Ops::new(9);
+        let rhs = U24Ops::new(3);
+        let ratio = Div::div(lhs, rhs);
+        assert_eq!(ratio.into(), 3_u128);
+    }
+
+    #[test]
+    fn test_bit_or_u24() {
+        let lhs = U24Ops::new(0b11110000101010101111);
+        let rhs = U24Ops::new(0b00001111010101010000);
+        assert_eq!(BitOr::bitor(lhs, rhs).data, 0xfffff_u128);
+    }
+
+    #[test]
+    fn test_bit_and_u24() {
+        let lhs = U24Ops::new(0b11110000101010101111);
+        let rhs = U24Ops::new(0b00001111010101010000);
+        assert_eq!(BitAnd::bitand(lhs, rhs).data, 0_u128);
+
+        let lhs = U24Ops::new(0b11110000101010101111);
+        let rhs = U24Ops::new(0b10101010101010101010);
+        assert_eq!(BitAnd::bitand(lhs, rhs).data, 0b10100000101010101010_u128);
+    }
+}

--- a/compiler-rt/src/integer/u40.cairo
+++ b/compiler-rt/src/integer/u40.cairo
@@ -4,15 +4,24 @@ use core::num::traits::{
 };
 use core::traits::Rem;
 use core::traits::Div;
+use crate::integer::IntegerOps;
+use crate::utils::assert_fits_in_type;
 
-// The struct to represent 40bit integers.
-//
-// 40bit integers are stored internally in a u128 field.
-// Every time a `u40` integer is used, it's important to ensure the value in the field `data` fits
-// within 40bits.
+/// The struct to represent 40-bit integers.
+///
+/// 40-bit integers are stored internally in a u128 value. Every time a `u40`
+/// integer is used, it's important to ensure the value in the field `data` fits
+/// within 40 bits.
 #[derive(Debug, Drop, PartialEq)]
 pub struct u40 {
     data: u128,
+}
+
+impl U40IntegerOps of IntegerOps<u40> {
+    fn new(value: u128) -> u40 {
+        assert_fits_in_type::<u40>(value);
+        u40 { data: value }
+    }
 }
 
 impl U40IntoU128 of Into<u40, u128> {
@@ -140,6 +149,8 @@ mod tests {
     use super::u40;
     use crate::utils::assert_fits_in_type;
 
+    use super::U40IntegerOps as U40Ops;
+
     use core::num::traits::BitSize;
     use core::num::traits::WrappingAdd;
     use core::num::traits::WrappingSub;
@@ -150,25 +161,21 @@ mod tests {
     use core::traits::Rem;
     use core::traits::Div;
 
-    fn u40_new(value: u128) -> u40 {
-        value.try_into().unwrap()
-    }
-
     #[test]
     fn test_u40() {
-        assert_eq!(u40_new(0).into(), 0_u128);
-        assert_eq!(u40_new(3).into(), 3_u128);
+        assert_eq!(U40Ops::new(0).into(), 0_u128);
+        assert_eq!(U40Ops::new(3).into(), 3_u128);
         assert_eq!(
-            u40_new(0b1111111111111111111111111111111111111111).into(),
+            U40Ops::new(0b1111111111111111111111111111111111111111).into(),
             0b1111111111111111111111111111111111111111_u128,
         );
         assert_fits_in_type::<u40>(10);
     }
 
     #[test]
-    #[should_panic]
-    fn test_panic_u40() {
-        u40_new(0b10000000000000000000000000000000000000000); // 2^40+1
+    #[should_panic(expected: "value = 1099511627776 does not fit in u40")]
+    fn u40_fails_to_construct_if_too_large() {
+        U40Ops::new(0b10000000000000000000000000000000000000000); // 2^40+1
     }
 
     #[test]
@@ -179,37 +186,37 @@ mod tests {
 
     #[test]
     fn test_eq_u40() {
-        let a = u40_new(3);
-        let b = u40_new(3);
+        let a = U40Ops::new(3);
+        let b = U40Ops::new(3);
         assert_eq!(a, b);
 
-        let c = u40_new(0);
+        let c = U40Ops::new(0);
         assert_ne!(a, c);
     }
 
     #[test]
     fn test_wrapping_add_u40() {
-        let lhs = u40_new(3);
-        let rhs = u40_new(8);
+        let lhs = U40Ops::new(3);
+        let rhs = U40Ops::new(8);
         let sum = lhs.wrapping_add(rhs);
         assert_eq!(sum.into(), 11_u128);
 
-        let lhs = u40_new(0b1111111111111111111111111111111111111111);
-        let rhs = u40_new(1);
+        let lhs = U40Ops::new(0b1111111111111111111111111111111111111111);
+        let rhs = U40Ops::new(1);
         let sum = lhs.wrapping_add(rhs);
         assert_eq!(sum.into(), 0_u128);
     }
 
     #[test]
     fn test_overflowing_add_u40() {
-        let lhs = u40_new(3);
-        let rhs = u40_new(8);
+        let lhs = U40Ops::new(3);
+        let rhs = U40Ops::new(8);
         let (sum, is_overflow) = lhs.overflowing_add(rhs);
         assert_eq!(sum.into(), 11_u128);
         assert_eq!(is_overflow, false);
 
-        let lhs = u40_new(0b1111111111111111111111111111111111111111);
-        let rhs = u40_new(1);
+        let lhs = U40Ops::new(0b1111111111111111111111111111111111111111);
+        let rhs = U40Ops::new(1);
         let (sum, is_overflow) = lhs.overflowing_add(rhs);
         assert_eq!(sum.into(), 0_u128);
         assert_eq!(is_overflow, true);
@@ -217,27 +224,27 @@ mod tests {
 
     #[test]
     fn test_wrapping_sub_u40() {
-        let lhs = u40_new(8);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(8);
+        let rhs = U40Ops::new(3);
         let diff = lhs.wrapping_sub(rhs);
         assert_eq!(diff.into(), 5_u128);
 
-        let lhs = u40_new(0);
-        let rhs = u40_new(1);
+        let lhs = U40Ops::new(0);
+        let rhs = U40Ops::new(1);
         let diff = lhs.wrapping_sub(rhs);
         assert_eq!(diff.into(), 0b1111111111111111111111111111111111111111_u128);
     }
 
     #[test]
     fn test_overflowing_sub_u40() {
-        let lhs = u40_new(8);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(8);
+        let rhs = U40Ops::new(3);
         let (diff, is_overflow) = lhs.overflowing_sub(rhs);
         assert_eq!(diff.into(), 5_u128);
         assert_eq!(is_overflow, false);
 
-        let lhs = u40_new(0);
-        let rhs = u40_new(1);
+        let lhs = U40Ops::new(0);
+        let rhs = U40Ops::new(1);
         let (diff, is_overflow) = lhs.overflowing_sub(rhs);
         assert_eq!(diff.into(), 0b1111111111111111111111111111111111111111_u128);
         assert_eq!(is_overflow, true);
@@ -245,27 +252,27 @@ mod tests {
 
     #[test]
     fn test_wrapping_mul_u40() {
-        let lhs = u40_new(8);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(8);
+        let rhs = U40Ops::new(3);
         let product = lhs.wrapping_mul(rhs);
         assert_eq!(product.into(), 24_u128);
 
-        let lhs = u40_new(0b1111111111111111111111111111111111111111);
-        let rhs = u40_new(2);
+        let lhs = U40Ops::new(0b1111111111111111111111111111111111111111);
+        let rhs = U40Ops::new(2);
         let product = lhs.wrapping_mul(rhs);
         assert_eq!(product.into(), 0b1111111111111111111111111111111111111110_u128);
     }
 
     #[test]
     fn test_overflowing_mul_u40() {
-        let lhs = u40_new(8);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(8);
+        let rhs = U40Ops::new(3);
         let (product, is_overflow) = lhs.overflowing_mul(rhs);
         assert_eq!(product.into(), 24_u128);
         assert_eq!(is_overflow, false);
 
-        let lhs = u40_new(0b1111111111111111111111111111111111111111);
-        let rhs = u40_new(2);
+        let lhs = U40Ops::new(0b1111111111111111111111111111111111111111);
+        let rhs = U40Ops::new(2);
         let (product, is_overflow) = lhs.overflowing_mul(rhs);
         assert_eq!(product.into(), 0b1111111111111111111111111111111111111110_u128);
         assert_eq!(is_overflow, true);
@@ -273,16 +280,16 @@ mod tests {
 
     #[test]
     fn test_rem_u40() {
-        let lhs = u40_new(8);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(8);
+        let rhs = U40Ops::new(3);
         let remainder = Rem::rem(lhs, rhs);
         assert_eq!(remainder.into(), 2_u128);
     }
 
     #[test]
     fn test_div_u40() {
-        let lhs = u40_new(9);
-        let rhs = u40_new(3);
+        let lhs = U40Ops::new(9);
+        let rhs = U40Ops::new(3);
         let ratio = Div::div(lhs, rhs);
         assert_eq!(ratio.into(), 3_u128);
     }


### PR DESCRIPTION
# Summary

This type serves as a backing for our `i24` polyfill operations by implementing the behavior required of a primitive integer in Cairo.

Additionally, it adds the `IntegerOps` trait that all of these non-standard integers should implement, as well as refactors `u40` to use that operation as well.

# Details

Check that things make sense, as ever! This implements the backing type for #155, but none of the actual polyfill operations.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
