### PR TITLE
Ensure that hieratika-cairoc compiles compiler-rt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,8 +1450,8 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-utils",
  "hieratika-errors",
- "hieratika-flo",
  "itertools 0.14.0",
+ "miette",
  "rayon",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,7 @@ inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0c1
 ] }
 itertools = "0.14.0"
 hieratika-cairoc = { path = "crates/cairoc" }
-hieratika-cli = { path = "crates/cli" }
 hieratika-compiler = { path = "crates/compiler" }
-hieratika-driver = { path = "crates/driver" }
 hieratika-errors = { path = "crates/error" }
 hieratika-flo = { path = "crates/flo" }
 hieratika-mangler = { path = "crates/mangler" }

--- a/compiler-rt/Scarb.toml
+++ b/compiler-rt/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_rt"
 version = "0.1.0"
-edition = "2024_07"
+edition = "2024_07"  # This must be kept in sync with the `cairo_project.toml` file in the same folder.
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 

--- a/compiler-rt/cairo_project.toml
+++ b/compiler-rt/cairo_project.toml
@@ -1,0 +1,5 @@
+[crate_roots]
+compiler-rt = "src"
+
+[config.global]
+edition = "2024_07" # This must be kept in sync with the `Scarb.toml` file in the same folder.

--- a/crates/cairoc/Cargo.toml
+++ b/crates/cairoc/Cargo.toml
@@ -22,9 +22,9 @@ cairo-lang-semantic = { path = "../../cairo/crates/cairo-lang-semantic" }
 cairo-lang-sierra-generator.workspace = true
 cairo-lang-utils.workspace = true
 hieratika-errors.workspace = true
-hieratika-flo.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
 itertools.workspace = true
+miette.workspace = true
 rayon = "1.10.0"

--- a/crates/cairoc/src/lib.rs
+++ b/crates/cairoc/src/lib.rs
@@ -112,8 +112,10 @@ fn get_flat_lowered_function(
     }
 }
 
-/// This function returns the `FlatLowered` object of a Cairo program. The
-/// filename can be either a project or a single file.
+/// This function returns the `FlatLowered` object of a Cairo program.
+///
+/// The filename can be either a single file, or a path to a cairo project in
+/// the form of a directory containing a `cairo_project.toml` file.
 ///
 /// # Errors
 ///
@@ -179,7 +181,7 @@ pub fn generate_sierra_all_crates(db: &RootDatabase) -> Result<CrateSierra> {
     generate_sierra(db, crate_ids)
 }
 
-/// Container for Cairo FlatLowered IR an its associated intern db.
+/// Container for Cairo FlatLowered IR and its associated intern db.
 pub struct CairoFlatLowered {
     /// A mapping between external symbol names and their associated Cairo
     /// FlatLowered objects.
@@ -202,6 +204,14 @@ mod test {
     use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
     use crate::{build_db, generate_flat_lowered, generate_sierra};
+
+    #[test]
+    fn can_compile_compiler_rt() -> miette::Result<()> {
+        let compiler_rt_project = Path::new("../../compiler-rt");
+        generate_flat_lowered(compiler_rt_project)?;
+
+        Ok(())
+    }
 
     #[test]
     fn flat_lowered_cairo_example_folder() {

--- a/crates/compiler/src/polyfill.rs
+++ b/crates/compiler/src/polyfill.rs
@@ -1403,15 +1403,6 @@ mod test {
         assert_eq!(count, 1561);
     }
 
-    #[ignore]
-    #[test]
-    fn print_all_polyfills() {
-        let polyfills = PolyfillMap::new();
-        polyfills
-            .iter()
-            .for_each(|(llvmop, name)| println!("{name} | {llvmop}"));
-    }
-
     #[test]
     fn polyfills_contain_no_invalid_chars() {
         let allowed_chars = Regex::new("^[0-9a-zA-Z_]+$").expect("Static regex did not compile");


### PR DESCRIPTION
# Summary

This adds a test that checks that the `cairoc` crate—the hieratika project's driver for the cairo compiler—is capable of compiling the `compiler-rt` project containing our polyfill definitions.

# Details

There are also some miscellaneous cleanups of the `Cargo.toml` dependencies to keep things in the minimally-required set of deps to compile.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
