### PR TITLE
Bump project dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,19 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-
-[[package]]
-name = "ariadne"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31beedec3ce83ae6da3a79592b3d8d7afd146a5b15bb9bb940279aced60faa89"
-dependencies = [
- "unicode-width",
- "yansi",
-]
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "ark-ec"
@@ -394,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -944,12 +934,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chumsky"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+checksum = "fb7314158bb843d046a78540774db3d78518f5150ea7109e9c8da864d45a738c"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
+ "regex-automata 0.3.9",
+ "serde",
  "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1369,8 +1363,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1509,7 +1503,7 @@ dependencies = [
  "inkwell",
  "itertools 0.14.0",
  "miette",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1526,22 +1520,16 @@ dependencies = [
 name = "hieratika-lifter"
 version = "0.1.0"
 dependencies = [
- "ariadne",
  "bimap",
  "cairo-lang-compiler",
  "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
  "cairo-lang-lowering",
  "cairo-lang-semantic",
  "cairo-lang-utils",
- "clap",
  "hieratika-cairoc",
  "hieratika-compiler",
  "hieratika-errors",
  "hieratika-flo",
- "itertools 0.14.0",
- "tracing",
 ]
 
 [[package]]
@@ -1593,7 +1581,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1640,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inkwell"
@@ -1772,7 +1760,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1786,7 +1774,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -1930,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -1950,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2110,9 +2098,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "ouroboros"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944fa20996a25aded6b4795c6d63f10014a7a83f8be9828a11860b08c5fc4a67"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -2121,12 +2109,11 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -2509,8 +2496,19 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2521,7 +2519,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2529,6 +2527,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3039,11 +3043,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3059,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@
 [workspace]
 resolver = "2"
 members = [
+  "crates/cairoc",
   "crates/cli",
   "crates/compiler",
   "crates/driver",
   "crates/error",
-  "crates/cairoc",
   "crates/flo",
-  "crates/test-utils",
-  "crates/mangler",
   "crates/lifter",
+  "crates/mangler",
+  "crates/test-utils",
 ]
 
-# Cairo is excluded because it is imported as git submodule and it has its own Cargo workspace.
+# Cairo is excluded because it is imported as git submodule that has its own Cargo workspace.
 exclude = ["cairo", "tests"]
 
 # Here we set keys that are relevant across all packages, allowing them to be inherited.
@@ -34,8 +34,8 @@ rust-version = "1.83.0"
 # Dependencies that are used by more than one crate are specified here, allowing us to ensure that
 # we match versions in all crates.
 [workspace.dependencies]
-anyhow = "1.0.89"
-ariadne = "0.5.0"
+anyhow = "1.0.97"
+ariadne = "0.5.1"
 backtrace = "0.3.74"
 bimap = { version = "0.6.3", features = ["serde"] }
 cairo-lang-compiler = { path = "cairo/crates/cairo-lang-compiler" }
@@ -57,11 +57,10 @@ hieratika-errors = { path = "crates/error" }
 hieratika-flo = { path = "crates/flo" }
 hieratika-mangler = { path = "crates/mangler" }
 hieratika-test-utils = { path = "crates/test-utils" }
-miette = { version = "7.4.0", features = ["fancy"] }
+miette = { version = "7.5.0", features = ["fancy"] }
 starknet-types-core = "0.1.7"
-thiserror = "2.0.8"
+thiserror = "2.0.12"
 hieratika-lifter = { path = "crates/lifter" }
-tracing = "0.1.40"
 
 [profile.release]
 debug = true           # Include full debug information in release builds.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,7 +23,7 @@ hieratika-lifter.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
-indoc = "2.0.5"
+indoc = "2.0.6"
 
 [[bin]]
 name = "hieratika"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 
 [dependencies]
 bimap.workspace = true
-chumsky = "0.9.3"
+chumsky = "0.10.0"
 downcast-rs = "2.0.1"
 ethnum.workspace = true
 hieratika-errors.workspace = true
@@ -24,7 +24,7 @@ hieratika-mangler.workspace = true
 inkwell.workspace = true
 itertools.workspace = true
 miette.workspace = true
-ouroboros = "0.18.4"
+ouroboros = "0.18.5"
 rand = "0.9.0"
 
 [dev-dependencies]

--- a/crates/compiler/src/obj_gen/mod.rs
+++ b/crates/compiler/src/obj_gen/mod.rs
@@ -3639,8 +3639,10 @@ impl ObjectGenerator {
                 // bits of precision. We need to be able to work with constant values of the
                 // i128 type, so we are forced to parse them ourselves in this case.
                 let source_text = value.print_to_string().to_string();
-                let parsed_result =
-                    IntegerConstant::parser().parse(source_text.as_str()).map_err(|_| {
+                let parsed_result = IntegerConstant::parser()
+                    .parse(source_text.as_str())
+                    .into_result()
+                    .map_err(|_| {
                         Error::MalformedLLVM(format!(
                             "`{source_text}` is not a valid integer constant"
                         ))
@@ -3658,6 +3660,7 @@ impl ObjectGenerator {
             // compiler is concerned.
             let constant_expr = ConstantExpression::parser()
                 .parse(constant_expression_fragment.as_str())
+                .into_result()
                 .map_err(|_| {
                     Error::MalformedLLVM(format!(
                         "The expression `{constant_expression_fragment}` is not a valid integer \
@@ -3793,6 +3796,7 @@ impl ObjectGenerator {
             // compiler is concerned.
             let constant_expr = ConstantExpression::parser()
                 .parse(constant_expression_fragment.as_str())
+                .into_result()
                 .map_err(|_| {
                     Error::MalformedLLVM(format!(
                         "The expression `{constant_expression_fragment}` is not a valid pointer \

--- a/crates/compiler/src/parser/constant_expr.rs
+++ b/crates/compiler/src/parser/constant_expr.rs
@@ -2,8 +2,9 @@
 //! capabilities in Inkwell.
 
 use chumsky::{
+    IterParser,
     Parser,
-    prelude::{choice, filter, just},
+    prelude::{any, choice, just},
     recursive,
     text::whitespace,
 };
@@ -43,7 +44,7 @@ pub enum ConstantExpression {
 impl ConstantExpression {
     /// Parses an arbitrary constant expression in LLVM.
     #[must_use]
-    pub fn parser() -> impl SimpleParser<Self> {
+    pub fn parser<'a>() -> impl SimpleParser<'a, Self> {
         recursive::recursive(|parser| {
             choice((
                 Self::constant_name().map(Self::Name).padded_by(whitespace()),
@@ -61,14 +62,15 @@ impl ConstantExpression {
 
     /// Parses a constant name.
     #[must_use]
-    pub fn constant_name() -> impl SimpleParser<String> {
+    pub fn constant_name<'a>() -> impl SimpleParser<'a, String> {
         just("@").ignore_then(choice((Self::complex_name(), Self::simple_name())))
     }
 
     /// Parses a simple LLVM name, namely one _not_ enclosed by double quotes.
     #[must_use]
-    fn simple_name() -> impl SimpleParser<String> {
-        filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+    fn simple_name<'a>() -> impl SimpleParser<'a, String> {
+        any()
+            .filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
             .repeated()
             .at_least(1)
             .collect()
@@ -76,14 +78,15 @@ impl ConstantExpression {
 
     /// Parses a complex LLVM name, namely one enclosed in double quotes.
     #[must_use]
-    fn complex_name() -> impl SimpleParser<String> {
-        filter(|c: &char| {
-            c.is_alphanumeric() || *c == '_' || *c == '-' || *c == '$' || *c == '.' || *c == ':'
-        })
-        .repeated()
-        .at_least(1)
-        .collect()
-        .delimited_by(just("\""), just("\""))
+    fn complex_name<'a>() -> impl SimpleParser<'a, String> {
+        any()
+            .filter(|c: &char| {
+                c.is_alphanumeric() || *c == '_' || *c == '-' || *c == '$' || *c == '.' || *c == ':'
+            })
+            .repeated()
+            .at_least(1)
+            .collect()
+            .delimited_by(just("\""), just("\""))
     }
 }
 
@@ -106,30 +109,35 @@ mod constant_expression {
     fn can_parse_constant_names() {
         // Successes
         assert_eq!(
-            ConstantExpression::parser().parse("@foo_bar-baz"),
+            ConstantExpression::parser().parse("@foo_bar-baz").into_result(),
             Ok(ConstantExpression::Name("foo_bar-baz".into()))
         );
         assert_eq!(
-            ConstantExpression::parser().parse("@\"foo$bar..baz\""),
+            ConstantExpression::parser().parse("@\"foo$bar..baz\"").into_result(),
             Ok(ConstantExpression::Name("foo$bar..baz".into()))
         );
 
         // Failures
-        assert!(ConstantExpression::parser().parse("@\"foo_bar$baz").is_err());
+        assert!(
+            ConstantExpression::parser()
+                .parse("@\"foo_bar$baz")
+                .into_result()
+                .is_err()
+        );
     }
 
     #[test]
     fn can_parse_integer_constants() {
         // Successes
         assert_eq!(
-            ConstantExpression::parser().parse("i1 0"),
+            ConstantExpression::parser().parse("i1 0").into_result(),
             Ok(ConstantExpression::Integer(IntegerConstant::new(
                 LLVMType::bool,
                 0
             )))
         );
         assert_eq!(
-            ConstantExpression::parser().parse("i128 -37"),
+            ConstantExpression::parser().parse("i128 -37").into_result(),
             Ok(ConstantExpression::Integer(IntegerConstant::new(
                 LLVMType::i128,
                 -37
@@ -137,15 +145,17 @@ mod constant_expression {
         );
 
         // Failures
-        assert!(ConstantExpression::parser().parse("i64 a1").is_err());
-        assert!(ConstantExpression::parser().parse("i8 -a1128").is_err());
+        assert!(ConstantExpression::parser().parse("i64 a1").into_result().is_err());
+        assert!(ConstantExpression::parser().parse("i8 -a1128").into_result().is_err());
     }
 
     #[test]
     fn can_parse_ptrtoint_constants() {
         // Successes
         assert_eq!(
-            ConstantExpression::parser().parse("i128 ptrtoint (ptr @\"baz$bar\" to i128)"),
+            ConstantExpression::parser()
+                .parse("i128 ptrtoint (ptr @\"baz$bar\" to i128)")
+                .into_result(),
             Ok(ConstantExpression::PtrToInt(PtrToIntConstant {
                 int_type: LLVMType::i128,
                 pointer:  Box::new(ConstantExpression::Name("baz$bar".into())),
@@ -156,6 +166,7 @@ mod constant_expression {
         assert!(
             ConstantExpression::parser()
                 .parse("ptrtoint (@\"baz$bar\" to i128)")
+                .into_result()
                 .is_err()
         );
     }
@@ -164,7 +175,9 @@ mod constant_expression {
     fn can_parse_inttoptr_constants() {
         // Successes
         assert_eq!(
-            ConstantExpression::parser().parse("ptr inttoptr (i64 @foobar to ptr)"),
+            ConstantExpression::parser()
+                .parse("ptr inttoptr (i64 @foobar to ptr)")
+                .into_result(),
             Ok(ConstantExpression::IntToPtr(IntToPtrConstant {
                 int_type: LLVMType::i64,
                 integer:  Box::new(ConstantExpression::Name("foobar".into())),
@@ -175,6 +188,7 @@ mod constant_expression {
         assert!(
             ConstantExpression::parser()
                 .parse("ptr inttoptr i64 1 to ptr)")
+                .into_result()
                 .is_err()
         );
     }
@@ -184,7 +198,8 @@ mod constant_expression {
         // Successes
         assert_eq!(
             ConstantExpression::parser()
-                .parse("ptr blockaddress(@hieratika_test_input, %exit_safe)"),
+                .parse("ptr blockaddress(@hieratika_test_input, %exit_safe)")
+                .into_result(),
             Ok(ConstantExpression::Blockaddress(BlockAddress {
                 function_name: "hieratika_test_input".into(),
                 block_ref:     "exit_safe".into(),
@@ -195,16 +210,19 @@ mod constant_expression {
         assert!(
             ConstantExpression::parser()
                 .parse("ptr blockaddress(@hieratika_test_input, %exit_safe")
+                .into_result()
                 .is_err()
         );
         assert!(
             ConstantExpression::parser()
                 .parse("ptr blockaddress(@hieratika_test_input)")
+                .into_result()
                 .is_err()
         );
         assert!(
             ConstantExpression::parser()
                 .parse("ptr blockaddress(hieratika_test_input, exit_safe)")
+                .into_result()
                 .is_err()
         );
     }

--- a/crates/compiler/src/parser/integer_constant.rs
+++ b/crates/compiler/src/parser/integer_constant.rs
@@ -31,7 +31,7 @@ impl IntegerConstant {
 
     /// Parses the integer constant from the LLVM IR source text.
     #[must_use]
-    pub fn parser() -> impl SimpleParser<Self> {
+    pub fn parser<'a>() -> impl SimpleParser<'a, Self> {
         typ::integer()
             .then_ignore(whitespace())
             .then(integer::<i128>(10))
@@ -43,45 +43,48 @@ impl IntegerConstant {
 mod test {
     use chumsky::Parser;
 
-    use super::IntegerConstant;
-    use crate::llvm::typesystem::LLVMType;
+    use crate::{llvm::typesystem::LLVMType, parser::integer_constant::IntegerConstant};
 
     #[test]
     fn can_parse_integer_constants() {
         // Successes
         assert_eq!(
-            IntegerConstant::parser().parse("i1 0"),
+            IntegerConstant::parser().parse("i1 0").into_result(),
             Ok(IntegerConstant::new(LLVMType::bool, 0))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i1 1"),
+            IntegerConstant::parser().parse("i1 1").into_result(),
             Ok(IntegerConstant::new(LLVMType::bool, 1))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i8 10"),
+            IntegerConstant::parser().parse("i8 10").into_result(),
             Ok(IntegerConstant::new(LLVMType::i8, 10))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i128 -37"),
+            IntegerConstant::parser().parse("i128 -37").into_result(),
             Ok(IntegerConstant::new(LLVMType::i128, -37))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i64 10"),
+            IntegerConstant::parser().parse("i64 10").into_result(),
             Ok(IntegerConstant::new(LLVMType::i64, 10))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i24 -37"),
+            IntegerConstant::parser().parse("i24 -37").into_result(),
             Ok(IntegerConstant::new(LLVMType::i24, -37))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i128 -4176471573560389552232087451844504212"),
+            IntegerConstant::parser()
+                .parse("i128 -4176471573560389552232087451844504212")
+                .into_result(),
             Ok(IntegerConstant::new(
                 LLVMType::i128,
                 -4_176_471_573_560_389_552_232_087_451_844_504_212
             ))
         );
         assert_eq!(
-            IntegerConstant::parser().parse("i128 -170141183460469231731687303715884105728"),
+            IntegerConstant::parser()
+                .parse("i128 -170141183460469231731687303715884105728")
+                .into_result(),
             Ok(IntegerConstant::new(
                 LLVMType::i128,
                 -170_141_183_460_469_231_731_687_303_715_884_105_728
@@ -89,7 +92,7 @@ mod test {
         );
 
         // Failures
-        assert!(IntegerConstant::parser().parse("i64 a1").is_err());
-        assert!(IntegerConstant::parser().parse("i8 -a1128").is_err());
+        assert!(IntegerConstant::parser().parse("i64 a1").into_result().is_err());
+        assert!(IntegerConstant::parser().parse("i8 -a1128").into_result().is_err());
     }
 }

--- a/crates/compiler/src/parser/mod.rs
+++ b/crates/compiler/src/parser/mod.rs
@@ -9,14 +9,17 @@ pub mod number;
 pub mod ptrtoint_constant;
 pub mod typ;
 
-use chumsky::{Parser, error::Simple};
+use chumsky::{Parser, error::Rich, extra};
 
 /// A way to avoid typing out the whole parser type parameter specification
 /// every time it is needed, given it only varies in a single parameter.
 ///
 /// Ideally this would be impl-trait-in-type-alias but that is not yet
 /// supported.
-pub trait SimpleParser<T>: Parser<char, T, Error = Simple<char>> + Clone {}
+pub trait SimpleParser<'a, T>: Parser<'a, &'a str, T, extra::Err<Rich<'a, char>>> + Clone {}
 
 /// A blanket impl to make this work because Rust.
-impl<T, U> SimpleParser<T> for U where U: Parser<char, T, Error = Simple<char>> + Clone {}
+impl<'a, T, U> SimpleParser<'a, T> for U where
+    U: Parser<'a, &'a str, T, extra::Err<Rich<'a, char>>> + Clone
+{
+}

--- a/crates/compiler/src/parser/number.rs
+++ b/crates/compiler/src/parser/number.rs
@@ -2,21 +2,21 @@
 
 use std::str::FromStr;
 
-use chumsky::{Parser, error::Simple, prelude::just, text};
+use chumsky::{Parser, error::Rich, prelude::just, text};
 
 use crate::parser::SimpleParser;
 
 /// Parses a positive or negative integer in the specified `radix`.
 #[must_use]
-pub fn integer<T: FromStr>(radix: u32) -> impl SimpleParser<T> {
+pub fn integer<'a, T: FromStr>(radix: u32) -> impl SimpleParser<'a, T> {
     just("-")
         .or_not()
         .then(text::int(radix))
-        .try_map(|(uminus, num): (_, String), span| {
+        .try_map(|(uminus, num): (_, &str), span| {
             let minus = uminus.unwrap_or_default();
             let actual_num = format!("{minus}{num}");
             let parsed_num = actual_num.parse::<T>().map_err(|_| {
-                Simple::custom(
+                Rich::custom(
                     span,
                     format!("Could not parse {num} as an {}", std::any::type_name::<T>()),
                 )
@@ -28,11 +28,10 @@ pub fn integer<T: FromStr>(radix: u32) -> impl SimpleParser<T> {
 
 /// Parses a positive integer in the specified `radix`.
 #[must_use]
-pub fn positive_integer(radix: u32) -> impl SimpleParser<usize> {
-    text::int(radix).try_map(|num: String, span| {
-        num.parse::<usize>().map_err(|_| {
-            Simple::custom(span, format!("Could not parse {num} as a positive integer"))
-        })
+pub fn positive_integer<'a>(radix: u32) -> impl SimpleParser<'a, usize> {
+    text::int(radix).try_map(|num: &str, span| {
+        num.parse::<usize>()
+            .map_err(|_| Rich::custom(span, format!("Could not parse {num} as a positive integer")))
     })
 }
 
@@ -43,35 +42,35 @@ mod test {
     #[test]
     fn can_parse_arbitrary_integers() {
         // Successes
-        assert_eq!(super::integer::<i128>(10).parse("0"), Ok(0));
-        assert_eq!(super::integer::<i128>(10).parse("1"), Ok(1));
-        assert_eq!(super::integer::<i128>(10).parse("-1"), Ok(-1));
+        assert_eq!(super::integer::<i128>(10).parse("0").into_result(), Ok(0));
+        assert_eq!(super::integer::<i128>(10).parse("1").into_result(), Ok(1));
+        assert_eq!(super::integer::<i128>(10).parse("-1").into_result(), Ok(-1));
         assert_eq!(
-            super::integer::<i128>(10).parse("123456789"),
+            super::integer::<i128>(10).parse("123456789").into_result(),
             Ok(123_456_789)
         );
         assert_eq!(
-            super::integer::<i128>(10).parse("-123456789"),
+            super::integer::<i128>(10).parse("-123456789").into_result(),
             Ok(-123_456_789)
         );
 
         // Failures
-        assert!(super::integer::<i128>(10).parse("foo").is_err());
-        assert!(super::integer::<i128>(10).parse("a1").is_err());
+        assert!(super::integer::<i128>(10).parse("foo").into_result().is_err());
+        assert!(super::integer::<i128>(10).parse("a1").into_result().is_err());
     }
 
     #[test]
     fn can_parse_positive_integers() {
         // Successes
-        assert_eq!(super::positive_integer(10).parse("0"), Ok(0));
-        assert_eq!(super::positive_integer(10).parse("1"), Ok(1));
+        assert_eq!(super::positive_integer(10).parse("0").into_result(), Ok(0));
+        assert_eq!(super::positive_integer(10).parse("1").into_result(), Ok(1));
         assert_eq!(
-            super::positive_integer(10).parse("123456789"),
+            super::positive_integer(10).parse("123456789").into_result(),
             Ok(123_456_789)
         );
 
         // Failures
-        assert!(super::positive_integer(10).parse("-1").is_err());
-        assert!(super::positive_integer(10).parse("-123456789").is_err());
+        assert!(super::positive_integer(10).parse("-1").into_result().is_err());
+        assert!(super::positive_integer(10).parse("-123456789").into_result().is_err());
     }
 }

--- a/crates/lifter/Cargo.toml
+++ b/crates/lifter/Cargo.toml
@@ -14,18 +14,12 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-ariadne.workspace = true
-clap.workspace = true
 cairo-lang-compiler.workspace = true
 cairo-lang-defs = { path = "../../cairo/crates/cairo-lang-defs" }
-cairo-lang-diagnostics = { path = "../../cairo/crates/cairo-lang-diagnostics" }
-cairo-lang-filesystem = { path = "../../cairo/crates/cairo-lang-filesystem" }
 cairo-lang-lowering.workspace = true
 cairo-lang-semantic = { path = "../../cairo/crates/cairo-lang-semantic" }
 cairo-lang-utils = { path = "../../cairo/crates/cairo-lang-utils" }
 hieratika-compiler.workspace = true
-itertools.workspace = true
-tracing.workspace = true
 hieratika-cairoc.workspace = true
 hieratika-flo.workspace = true
 hieratika-errors.workspace = true


### PR DESCRIPTION
# Summary

This commit updates the project's dependencies across all the crates to the latest versions unless otherwise noted.

This involves a re-write of the components that rely on Chumsky, as the crate's interface has been re-written for the 0.10.0 release. When writing the parsing sections, it was incorrect to depend on the 0.9.0 release as this was old and not a reflection of modern parsing practice. This upgrade fixes this oversight, and also improves parsing speed.

# Details

The parser changes should be very minor, even though a reasonable number of lines have changed. Please carefully check for anything that shoudl change semantics.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
