### PR TITLE
Update the nightly compiler

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 # Environment variables that will be set on all runners
 env:
-  DEV_SHELL: "nix develop '.#ci'"
+  DEV_SHELL: "nix develop -L '.#ci'"
   CARGO_TERM_COLOR: always # Always colour Cargo's output.
   CARGO_INCREMENTAL: 0 # Always run without incremental builds on CI.
   CARGO_PROFILE_DEV_DEBUG: 0 # Don't embed debug info even though the build is a dev build.
@@ -40,7 +40,8 @@ jobs:
         with:
           path: |
             target/
-          key: rust-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.os }}
+          key:
+            rust-${{ hashFiles('**/Cargo.lock') }}-{{ hashFiles('**/flake.lock') }}-${{ matrix.os }}
       - name: Build Lix Dependencies
         shell: "bash"
         run: |
@@ -80,7 +81,7 @@ jobs:
         with:
           path: |
             target/
-          key: rust-${{ hashFiles('**/Cargo.lock') }}-ubuntu-latest
+          key: rust-${{ hashFiles('**/Cargo.lock') }}-{{ hashFiles('**/flake.lock') }}-ubuntu-latest
       - name: Build Lix Dependencies
         shell: bash
         run: |
@@ -116,7 +117,7 @@ jobs:
         with:
           path: |
             target/
-          key: rust-${{ hashFiles('**/Cargo.lock') }}-ubuntu-latest
+          key: rust-${{ hashFiles('**/Cargo.lock') }}-{{ hashFiles('**/flake.lock') }}-ubuntu-latest
       - name: Build Lix Dependencies
         shell: bash
         run: |
@@ -154,7 +155,7 @@ jobs:
         with:
           path: |
             target/
-          key: rust-${{ hashFiles('**/Cargo.lock') }}-ubuntu-latest
+          key: rust-${{ hashFiles('**/Cargo.lock') }}-{{ hashFiles('**/flake.lock') }}-ubuntu-latest
       - name: Build Lix Dependencies
         shell: bash
         run: |

--- a/crates/compiler/build.rs
+++ b/crates/compiler/build.rs
@@ -10,6 +10,8 @@ const TARGET_DIR: &str = "input/compilation";
 /// directory if they do not exist.
 #[allow(clippy::permissions_set_readonly_false)] // We do not care if it is world-writable
 fn main() {
+    println!("cargo:rerun-if-changed=../../flake.lock");
+    println!("cargo:rerun-if-changed=../../flake.nix");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=inputs/compilation");
 
@@ -45,6 +47,7 @@ fn main() {
                 .permissions();
             perms.set_readonly(false);
             fs::set_permissions(&target_path, perms.clone()).expect("Could not set permissions");
+            fs::remove_file(&target_path).expect("Could not remove existing file");
         }
 
         // Actually copy the file.

--- a/crates/compiler/src/llvm/data_layout.rs
+++ b/crates/compiler/src/llvm/data_layout.rs
@@ -843,6 +843,7 @@ mod test {
     };
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn can_parse_data_layout() {
         let dl_string = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128";
 
@@ -864,13 +865,16 @@ mod test {
         assert_eq!(layout.alloc_address_space, 0);
 
         // Pointers in address space zero are aligned to 64 bits.
-        assert_eq!(layout.pointer_layouts, vec![PointerLayout {
-            address_space:       0,
-            size:                64,
-            abi_alignment:       64,
-            preferred_alignment: 64,
-            index_size:          64,
-        }]);
+        assert_eq!(
+            layout.pointer_layouts,
+            vec![PointerLayout {
+                address_space:       0,
+                size:                64,
+                abi_alignment:       64,
+                preferred_alignment: 64,
+                index_size:          64,
+            }]
+        );
 
         // Integers are semi-customized, with 8, 16, 64, and 128 using layouts specified
         // in the string
@@ -940,21 +944,30 @@ mod test {
         }));
 
         // For the aggregate layout we have the default
-        assert_eq!(layout.aggregate_layout, AggregateLayout {
-            abi_alignment:       0,
-            preferred_alignment: 64,
-        });
+        assert_eq!(
+            layout.aggregate_layout,
+            AggregateLayout {
+                abi_alignment:       0,
+                preferred_alignment: 64,
+            }
+        );
 
         // For the function pointer layout we also have our default
-        assert_eq!(layout.function_pointer_layout, FunctionPointerLayout {
-            ptr_type:      FunctionPointerType::Independent,
-            abi_alignment: 64,
-        });
+        assert_eq!(
+            layout.function_pointer_layout,
+            FunctionPointerLayout {
+                ptr_type:      FunctionPointerType::Independent,
+                abi_alignment: 64,
+            }
+        );
 
         // For native integer widths this string specifies 32, 64
-        assert_eq!(layout.native_integer_widths, NativeIntegerWidths {
-            widths: vec![32, 64],
-        });
+        assert_eq!(
+            layout.native_integer_widths,
+            NativeIntegerWidths {
+                widths: vec![32, 64],
+            }
+        );
 
         // And no address spaces should be using non-integral pointers
         assert_eq!(
@@ -966,6 +979,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn can_parse_data_layout_to_default() {
         let dl_string = "";
 
@@ -987,13 +1001,16 @@ mod test {
         assert_eq!(layout.alloc_address_space, 0);
 
         // Pointers in address space zero are aligned to 64 bits.
-        assert_eq!(layout.pointer_layouts, vec![PointerLayout {
-            address_space:       0,
-            size:                64,
-            abi_alignment:       64,
-            preferred_alignment: 64,
-            index_size:          64,
-        }]);
+        assert_eq!(
+            layout.pointer_layouts,
+            vec![PointerLayout {
+                address_space:       0,
+                size:                64,
+                abi_alignment:       64,
+                preferred_alignment: 64,
+                index_size:          64,
+            }]
+        );
 
         // All the integer layouts should be default
         assert!(layout.integer_layouts.contains(&IntegerLayout {
@@ -1057,21 +1074,30 @@ mod test {
         }));
 
         // For the aggregate layout we have the default
-        assert_eq!(layout.aggregate_layout, AggregateLayout {
-            abi_alignment:       0,
-            preferred_alignment: 64,
-        });
+        assert_eq!(
+            layout.aggregate_layout,
+            AggregateLayout {
+                abi_alignment:       0,
+                preferred_alignment: 64,
+            }
+        );
 
         // For the function pointer layout we also have our default
-        assert_eq!(layout.function_pointer_layout, FunctionPointerLayout {
-            ptr_type:      FunctionPointerType::Independent,
-            abi_alignment: 64,
-        });
+        assert_eq!(
+            layout.function_pointer_layout,
+            FunctionPointerLayout {
+                ptr_type:      FunctionPointerType::Independent,
+                abi_alignment: 64,
+            }
+        );
 
         // For native integer widths we should have the default
-        assert_eq!(layout.native_integer_widths, NativeIntegerWidths {
-            widths: vec![32, 64],
-        });
+        assert_eq!(
+            layout.native_integer_widths,
+            NativeIntegerWidths {
+                widths: vec![32, 64],
+            }
+        );
 
         // And no address spaces should be using non-integral pointers
         assert_eq!(

--- a/crates/compiler/src/llvm/special_intrinsics.rs
+++ b/crates/compiler/src/llvm/special_intrinsics.rs
@@ -31,44 +31,54 @@ impl SpecialIntrinsics {
     #[must_use]
     pub fn new() -> Self {
         let mut intrinsics = HashMap::new();
-        intrinsics.insert("llvm.dbg.declare".to_string(), FunctionInfo {
-            kind:        TopLevelEntryKind::Declaration,
-            intrinsic:   true,
-            typ:         LLVMFunction::new(LLVMType::void, &[
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-            ]),
-            param_names: vec![None, None, None],
-            linkage:     Linkage::External,
-            visibility:  GlobalVisibility::Default,
-        });
-        intrinsics.insert("llvm.dbg.value".to_string(), FunctionInfo {
-            kind:        TopLevelEntryKind::Declaration,
-            intrinsic:   true,
-            typ:         LLVMFunction::new(LLVMType::void, &[
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-            ]),
-            param_names: vec![None, None, None],
-            linkage:     Linkage::External,
-            visibility:  GlobalVisibility::Default,
-        });
-        intrinsics.insert("llvm.dbg.assign".to_string(), FunctionInfo {
-            kind:        TopLevelEntryKind::Declaration,
-            intrinsic:   true,
-            typ:         LLVMFunction::new(LLVMType::void, &[
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-            ]),
-            param_names: vec![None, None, None, None, None],
-            linkage:     Linkage::External,
-            visibility:  GlobalVisibility::Default,
-        });
+        intrinsics.insert(
+            "llvm.dbg.declare".to_string(),
+            FunctionInfo {
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
+                    LLVMType::void,
+                    &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata],
+                ),
+                param_names: vec![None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
+            },
+        );
+        intrinsics.insert(
+            "llvm.dbg.value".to_string(),
+            FunctionInfo {
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
+                    LLVMType::void,
+                    &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata],
+                ),
+                param_names: vec![None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
+            },
+        );
+        intrinsics.insert(
+            "llvm.dbg.assign".to_string(),
+            FunctionInfo {
+                kind:        TopLevelEntryKind::Declaration,
+                intrinsic:   true,
+                typ:         LLVMFunction::new(
+                    LLVMType::void,
+                    &[
+                        LLVMType::Metadata,
+                        LLVMType::Metadata,
+                        LLVMType::Metadata,
+                        LLVMType::Metadata,
+                        LLVMType::Metadata,
+                    ],
+                ),
+                param_names: vec![None, None, None, None, None],
+                linkage:     Linkage::External,
+                visibility:  GlobalVisibility::Default,
+            },
+        );
 
         Self { intrinsics }
     }

--- a/crates/compiler/src/obj_gen/data.rs
+++ b/crates/compiler/src/obj_gen/data.rs
@@ -302,6 +302,7 @@ impl ObjectContext {
             LLVMType::i48 => Type::Signed48,
             LLVMType::i64 => Type::Signed64,
             LLVMType::i128 => Type::Signed128,
+            LLVMType::i256 => Type::Signed256,
             LLVMType::f16 => Type::Half,
             LLVMType::f32 => Type::Float,
             LLVMType::f64 => Type::Double,

--- a/crates/compiler/src/parser/block_address.rs
+++ b/crates/compiler/src/parser/block_address.rs
@@ -1,17 +1,13 @@
 //! A parser for blockaddress constant pointer expressions.
 
-use chumsky::{
-    IterParser,
-    Parser,
-    prelude::{just, none_of},
-};
+use chumsky::{Parser, prelude::just};
 
-use crate::parser::SimpleParser;
+use crate::{parser, parser::SimpleParser};
 
 /// A representation of a [`blockaddress`](https://llvm.org/docs/LangRef.html#addresses-of-basic-blocks)
 /// constant expression, used to aid in the management of pointer constants.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct BlockAddress {
+pub struct BlockAddressConstant {
     /// The name of the function in which `block_ref` should be resolved.
     pub function_name: String,
 
@@ -20,7 +16,7 @@ pub struct BlockAddress {
     pub block_ref: String,
 }
 
-impl BlockAddress {
+impl BlockAddressConstant {
     /// Generates a parser for the `BlockAddress` type from the standard pointer
     /// constant `blockaddress` expression.
     #[must_use]
@@ -31,26 +27,12 @@ impl BlockAddress {
             .ignore_then(Self::arguments().delimited_by(just("("), just(")")))
     }
 
-    /// Parses a function name as it is expected to occur in the first argument
-    /// of the `blockaddress` constant.
-    #[must_use]
-    pub fn function_name<'a>() -> impl SimpleParser<'a, String> {
-        just("@").ignore_then(none_of("@%,()").repeated().collect::<String>())
-    }
-
-    /// Parses a block reference as it is expected to appear in the second
-    /// argument of the `blockaddress` constant.
-    #[must_use]
-    pub fn block_ref<'a>() -> impl SimpleParser<'a, String> {
-        just("%").ignore_then(none_of("@%,()").repeated().collect::<String>())
-    }
-
     /// Parses the arguments to the `blockaddress` constant expression.
     #[must_use]
-    pub fn arguments<'a>() -> impl SimpleParser<'a, BlockAddress> {
-        Self::function_name()
+    pub fn arguments<'a>() -> impl SimpleParser<'a, BlockAddressConstant> {
+        parser::global_name()
             .then_ignore(just(",").padded())
-            .then(Self::block_ref())
+            .then(parser::block_ref())
             .map(|(function_name, block_ref)| Self {
                 function_name,
                 block_ref,
@@ -62,53 +44,46 @@ impl BlockAddress {
 mod test {
     use chumsky::Parser;
 
-    use super::BlockAddress;
-
-    #[test]
-    fn can_parse_function_name_in_blockaddr() {
-        let result = BlockAddress::function_name()
-            .parse("@hieratika_test_indirectbr")
-            .into_result();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "hieratika_test_indirectbr");
-    }
-
-    #[test]
-    fn can_parse_block_ref_in_blockaddr() {
-        let result = BlockAddress::block_ref().parse("%bb1").into_result();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "bb1");
-    }
+    use super::BlockAddressConstant;
 
     #[test]
     fn can_parse_arguments_of_block_ref_in_blockaddr() {
-        let result = BlockAddress::arguments()
+        let result = BlockAddressConstant::arguments()
             .parse("@hieratika_test_indirectbr,%bb1")
             .into_result();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), BlockAddress {
-            function_name: "hieratika_test_indirectbr".to_string(),
-            block_ref:     "bb1".to_string(),
-        });
-        let result = BlockAddress::arguments()
+        assert_eq!(
+            result.unwrap(),
+            BlockAddressConstant {
+                function_name: "hieratika_test_indirectbr".to_string(),
+                block_ref:     "bb1".to_string(),
+            }
+        );
+        let result = BlockAddressConstant::arguments()
             .parse("@hieratika_test_indirectbr, %bb1")
             .into_result();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), BlockAddress {
-            function_name: "hieratika_test_indirectbr".to_string(),
-            block_ref:     "bb1".to_string(),
-        });
+        assert_eq!(
+            result.unwrap(),
+            BlockAddressConstant {
+                function_name: "hieratika_test_indirectbr".to_string(),
+                block_ref:     "bb1".to_string(),
+            }
+        );
     }
 
     #[test]
     fn can_parse_blockaddr() {
-        let result = BlockAddress::parser()
+        let result = BlockAddressConstant::parser()
             .parse("ptr blockaddress(@hieratika_test_input, %exit_safe)")
             .into_result();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), BlockAddress {
-            function_name: "hieratika_test_input".to_string(),
-            block_ref:     "exit_safe".to_string(),
-        });
+        assert_eq!(
+            result.unwrap(),
+            BlockAddressConstant {
+                function_name: "hieratika_test_input".to_string(),
+                block_ref:     "exit_safe".to_string(),
+            }
+        );
     }
 }

--- a/crates/compiler/src/parser/getelementptr_constant.rs
+++ b/crates/compiler/src/parser/getelementptr_constant.rs
@@ -1,0 +1,173 @@
+//! Handles parsing of constant `getelementptr` expressions.
+
+use chumsky::{
+    IterParser,
+    Parser,
+    primitive::{choice, just},
+};
+
+use crate::{
+    llvm::typesystem::LLVMType,
+    parser,
+    parser::{SimpleParser, integer_constant::IntegerConstant, typ},
+};
+
+/// A representation of the `getelementptr` constant expression, calculating the
+/// offset from the provided pointer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetElementPtrConstant {
+    /// The base type for the offset calculation.
+    pub pointee_type: LLVMType,
+
+    /// The name of the pointer being calculated from.
+    pub pointer_name: String,
+
+    /// The offsets from the base pointer.
+    pub offsets: Vec<IntegerConstant>,
+}
+
+impl GetElementPtrConstant {
+    /// Creates a parser for `getelementptr` constant expressions.
+    #[must_use]
+    pub fn parser<'a>() -> impl SimpleParser<'a, Self> {
+        just("ptr")
+            .padded()
+            .ignore_then(just("getelementptr").padded())
+            .ignore_then(Self::tags().padded())
+            .ignore_then(Self::optionally_parensed_body())
+    }
+
+    /// Creates a parser for the body of a `getelementptr` constant expression,
+    /// optionally surrounded by parentheses.
+    #[must_use]
+    fn optionally_parensed_body<'a>() -> impl SimpleParser<'a, Self> {
+        Self::body().delimited_by(just("("), just(")")).or(Self::body())
+    }
+
+    /// Creates a parser for the body of a `getelementptr` constant expression.
+    #[must_use]
+    fn body<'a>() -> impl SimpleParser<'a, Self> {
+        typ::any()
+            .then_ignore(Self::comma())
+            .then_ignore(just("ptr").padded())
+            .then(parser::global_name())
+            .then_ignore(Self::comma())
+            .then(Self::offset_list())
+            .map(|((pointee_type, pointer_name), offsets)| Self {
+                pointee_type,
+                pointer_name,
+                offsets,
+            })
+    }
+
+    /// Parses the list of offsets in the `getelementptr` instruction.
+    #[must_use]
+    fn offset_list<'a>() -> impl SimpleParser<'a, Vec<IntegerConstant>> {
+        IntegerConstant::parser()
+            .padded()
+            .separated_by(Self::comma())
+            .collect::<Vec<_>>()
+    }
+
+    /// Consumes any of the tags that dictate how `getelementptr` behaves as we
+    /// do not care about them in our use-case.
+    #[must_use]
+    fn tags<'a>() -> impl SimpleParser<'a, ()> {
+        choice((just("inbounds"), just("nuw"), just("nsw")))
+            .padded()
+            .repeated()
+            .ignored()
+    }
+
+    /// Parses a comma, potentially padded.
+    #[must_use]
+    fn comma<'a>() -> impl SimpleParser<'a, ()> {
+        just(",").padded().ignored()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use chumsky::Parser;
+
+    use crate::{
+        llvm::typesystem::LLVMType,
+        parser::{
+            getelementptr_constant::GetElementPtrConstant,
+            integer_constant::IntegerConstant,
+        },
+    };
+
+    #[test]
+    fn parses_getelementptr_offset_list() {
+        let input = "i64 8, i32 0, i128 4";
+        let result = GetElementPtrConstant::offset_list().parse(input);
+        assert!(!result.has_errors());
+        assert_eq!(
+            *result.output().unwrap(),
+            vec![
+                IntegerConstant::new(LLVMType::i64, 8),
+                IntegerConstant::new(LLVMType::i32, 0),
+                IntegerConstant::new(LLVMType::i128, 4)
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_getelementptr_body() {
+        let input = "i32, ptr @constptr, i64 8, i32 0, i128 4";
+        let result = GetElementPtrConstant::body().parse(input);
+        assert!(!result.has_errors());
+        assert_eq!(
+            *result.output().unwrap(),
+            GetElementPtrConstant {
+                pointee_type: LLVMType::i32,
+                pointer_name: "constptr".into(),
+                offsets:      vec![
+                    IntegerConstant::new(LLVMType::i64, 8),
+                    IntegerConstant::new(LLVMType::i32, 0),
+                    IntegerConstant::new(LLVMType::i128, 4)
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn parses_getelementptr() {
+        let input = "ptr getelementptr inbounds nuw (i32, ptr @constptr, i64 8)";
+        let result = GetElementPtrConstant::parser().parse(input);
+        assert!(!result.has_errors());
+        assert_eq!(
+            *result.output().unwrap(),
+            GetElementPtrConstant {
+                pointee_type: LLVMType::i32,
+                pointer_name: "constptr".into(),
+                offsets:      vec![IntegerConstant::new(LLVMType::i64, 8)],
+            }
+        );
+
+        let input = "ptr getelementptr (i32, ptr @constptr, i64 10)";
+        let result = GetElementPtrConstant::parser().parse(input);
+        assert!(!result.has_errors());
+        assert_eq!(
+            *result.output().unwrap(),
+            GetElementPtrConstant {
+                pointee_type: LLVMType::i32,
+                pointer_name: "constptr".into(),
+                offsets:      vec![IntegerConstant::new(LLVMType::i64, 10)],
+            }
+        );
+
+        let input = "ptr getelementptr i32, ptr @constptr, i64 12";
+        let result = GetElementPtrConstant::parser().parse(input);
+        assert!(!result.has_errors());
+        assert_eq!(
+            *result.output().unwrap(),
+            GetElementPtrConstant {
+                pointee_type: LLVMType::i32,
+                pointer_name: "constptr".into(),
+                offsets:      vec![IntegerConstant::new(LLVMType::i64, 12)],
+            }
+        );
+    }
+}

--- a/crates/compiler/src/parser/inttoptr_constant.rs
+++ b/crates/compiler/src/parser/inttoptr_constant.rs
@@ -3,7 +3,6 @@
 use chumsky::{
     Parser,
     prelude::{choice, just},
-    text::whitespace,
 };
 
 use crate::{
@@ -30,18 +29,16 @@ pub struct IntToPtrConstant {
 
 impl IntToPtrConstant {
     /// Creates a parser for `inttoptr` constant expressions with `child_expr`
-    /// expressions allowed in the
+    /// expressions allowed in expression positions.
     pub fn parser<'a>(
         child_expr: impl SimpleParser<'a, ConstantExpression>,
     ) -> impl SimpleParser<'a, Self> {
         just("ptr")
-            .ignore_then(just("inttoptr").padded_by(whitespace()))
+            .ignore_then(just("inttoptr").padded())
             .ignore_then(choice((
-                Self::t_lit_to_ptr()
-                    .padded_by(whitespace())
-                    .delimited_by(just("("), just(")")),
+                Self::t_lit_to_ptr().padded().delimited_by(just("("), just(")")),
                 Self::t_expr_to_ptr(child_expr)
-                    .padded_by(whitespace())
+                    .padded()
                     .delimited_by(just("("), just(")")),
             )))
     }
@@ -50,9 +47,9 @@ impl IntToPtrConstant {
     /// where `v` is a literal integer.
     fn t_lit_to_ptr<'a>() -> impl SimpleParser<'a, Self> {
         typ::integer()
-            .padded_by(whitespace())
-            .then(number::integer::<i128>(10).padded_by(whitespace()))
-            .then_ignore(Self::literal_to_ptr().padded_by(whitespace()))
+            .padded()
+            .then(number::integer::<i128>(10).padded())
+            .then_ignore(Self::literal_to_ptr().padded())
             .map(|(source_type, integer_value)| Self {
                 int_type: source_type.clone(),
                 integer:  Box::new(ConstantExpression::Integer(IntegerConstant {
@@ -68,9 +65,9 @@ impl IntToPtrConstant {
         child_expr: impl SimpleParser<'a, ConstantExpression>,
     ) -> impl SimpleParser<'a, Self> {
         typ::integer()
-            .padded_by(whitespace())
-            .then(child_expr.padded_by(whitespace()))
-            .then_ignore(Self::literal_to_ptr().padded_by(whitespace()))
+            .padded()
+            .then(child_expr.padded())
+            .then_ignore(Self::literal_to_ptr().padded())
             .map(|(source_type, integer_expr)| Self {
                 int_type: source_type.clone(),
                 integer:  Box::new(integer_expr),
@@ -80,10 +77,7 @@ impl IntToPtrConstant {
     /// Creates a parser for the `to ptr` portion of the `inttoptr` constant
     /// expression.
     fn literal_to_ptr<'a>() -> impl SimpleParser<'a, ()> {
-        just("to")
-            .padded_by(whitespace())
-            .ignore_then(just("ptr").padded_by(whitespace()))
-            .ignored()
+        just("to").padded().ignore_then(just("ptr").padded()).ignored()
     }
 }
 

--- a/crates/compiler/src/parser/mod.rs
+++ b/crates/compiler/src/parser/mod.rs
@@ -3,13 +3,20 @@
 
 pub mod block_address;
 pub mod constant_expr;
+pub mod getelementptr_constant;
 pub mod integer_constant;
 pub mod inttoptr_constant;
 pub mod number;
 pub mod ptrtoint_constant;
 pub mod typ;
 
-use chumsky::{Parser, error::Rich, extra};
+use chumsky::{
+    IterParser,
+    Parser,
+    error::Rich,
+    extra,
+    prelude::{just, none_of},
+};
 
 /// A way to avoid typing out the whole parser type parameter specification
 /// every time it is needed, given it only varies in a single parameter.
@@ -22,4 +29,37 @@ pub trait SimpleParser<'a, T>: Parser<'a, &'a str, T, extra::Err<Rich<'a, char>>
 impl<'a, T, U> SimpleParser<'a, T> for U where
     U: Parser<'a, &'a str, T, extra::Err<Rich<'a, char>>> + Clone
 {
+}
+
+/// Parses a global name.
+#[must_use]
+pub fn global_name<'a>() -> impl SimpleParser<'a, String> {
+    just("@").ignore_then(none_of("@%,()").repeated().collect::<String>())
+}
+
+/// Parses a block reference.
+#[must_use]
+pub fn block_ref<'a>() -> impl SimpleParser<'a, String> {
+    just("%").ignore_then(none_of("@%,()").repeated().collect::<String>())
+}
+
+#[cfg(test)]
+mod test {
+    use chumsky::Parser;
+
+    use crate::parser::{block_ref, global_name};
+
+    #[test]
+    fn can_parse_function_name_in_blockaddr() {
+        let result = global_name().parse("@hieratika_test_indirectbr").into_result();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hieratika_test_indirectbr");
+    }
+
+    #[test]
+    fn can_parse_block_ref_in_blockaddr() {
+        let result = block_ref().parse("%bb1").into_result();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "bb1");
+    }
 }

--- a/crates/compiler/src/parser/ptrtoint_constant.rs
+++ b/crates/compiler/src/parser/ptrtoint_constant.rs
@@ -1,6 +1,6 @@
 //! A parser for the `ptrtoint` constant expression.
 
-use chumsky::{Parser, prelude::just, text::whitespace};
+use chumsky::{Parser, prelude::just};
 
 use crate::{
     llvm::typesystem::LLVMType,
@@ -23,12 +23,9 @@ impl PtrToIntConstant {
     pub fn parser<'a>(
         child_expr: impl SimpleParser<'a, ConstantExpression>,
     ) -> impl SimpleParser<'a, Self> {
-        typ::integer()
-            .ignore_then(just("ptrtoint").padded_by(whitespace()))
-            .ignore_then(Self::ptr_to_t(child_expr).delimited_by(
-                just("(").padded_by(whitespace()),
-                just(")").padded_by(whitespace()),
-            ))
+        typ::integer().ignore_then(just("ptrtoint").padded()).ignore_then(
+            Self::ptr_to_t(child_expr).delimited_by(just("(").padded(), just(")").padded()),
+        )
     }
 
     /// Creates a parser for the `ptr x to T` portion of the `ptrtoint` constant
@@ -37,10 +34,10 @@ impl PtrToIntConstant {
         child_expr: impl SimpleParser<'a, ConstantExpression>,
     ) -> impl SimpleParser<'a, Self> {
         just("ptr")
-            .padded_by(whitespace())
-            .ignore_then(child_expr.padded_by(whitespace()))
-            .then_ignore(just("to").padded_by(whitespace()))
-            .then(typ::integer().padded_by(whitespace()))
+            .padded()
+            .ignore_then(child_expr.padded())
+            .then_ignore(just("to").padded())
+            .then(typ::integer().padded())
             .map(|(ptr_expr, target_type)| Self {
                 int_type: target_type,
                 pointer:  Box::new(ptr_expr),

--- a/crates/compiler/src/pass/analysis/module_map.rs
+++ b/crates/compiler/src/pass/analysis/module_map.rs
@@ -566,10 +566,10 @@ mod test {
         assert_eq!(global_2.kind, TopLevelEntryKind::Definition);
         assert_eq!(
             global_2.typ,
-            LLVMType::make_struct(true, &[
-                LLVMType::ptr,
-                LLVMType::make_array(16, LLVMType::i8)
-            ])
+            LLVMType::make_struct(
+                true,
+                &[LLVMType::ptr, LLVMType::make_array(16, LLVMType::i8)]
+            )
         );
 
         Ok(())
@@ -605,10 +605,10 @@ mod test {
             rust_test_input.typ,
             LLVMFunction::new(LLVMType::i64, &[LLVMType::i64, LLVMType::i64])
         );
-        assert_eq!(rust_test_input.param_names, vec![
-            Some("left".into()),
-            Some("right".into())
-        ]);
+        assert_eq!(
+            rust_test_input.param_names,
+            vec![Some("left".into()), Some("right".into())]
+        );
 
         // llvm.dbg.declare
         let llvm_dbg_declare = functions.get(&"llvm.dbg.declare".to_string()).unwrap();
@@ -618,11 +618,10 @@ mod test {
         assert_eq!(llvm_dbg_declare.visibility, GlobalVisibility::Default);
         assert_eq!(
             llvm_dbg_declare.typ,
-            LLVMFunction::new(LLVMType::void, &[
-                LLVMType::Metadata,
-                LLVMType::Metadata,
-                LLVMType::Metadata
-            ])
+            LLVMFunction::new(
+                LLVMType::void,
+                &[LLVMType::Metadata, LLVMType::Metadata, LLVMType::Metadata]
+            )
         );
         assert_eq!(llvm_dbg_declare.param_names, vec![None, None, None]);
 

--- a/crates/compiler/src/polyfill.rs
+++ b/crates/compiler/src/polyfill.rs
@@ -485,12 +485,8 @@ impl PolyfillMap {
     }
 
     fn getelementptr(&mut self) {
-        // This takes a pointer to an aggregate (either an array or a struct), and the
-        // offset (in felts) within that pointer that corresponds to the target element.
-        // It then returns a pointer to that element.
-        //
-        // This can only work at a single level, and so any usage needs to decompose
-        // this.
+        // This takes a pointer and the offset in bytes from that pointer that
+        // corresponds to the new pointer.
         self.mk(
             "getelementptr",
             &[LLVMType::ptr, LLVMType::i64],
@@ -1318,6 +1314,7 @@ impl PolyfillMap {
             LLVMType::i48,
             LLVMType::i64,
             LLVMType::i128,
+            LLVMType::i256,
         ]
     }
 
@@ -1400,7 +1397,7 @@ mod test {
     fn has_correct_polyfill_count() {
         let polyfills = PolyfillMap::new();
         let count = polyfills.iter().count();
-        assert_eq!(count, 1561);
+        assert_eq!(count, 1714);
     }
 
     #[test]

--- a/crates/compiler/tests/compilation_alloc.rs
+++ b/crates/compiler/tests/compilation_alloc.rs
@@ -10,8 +10,8 @@ fn compiles_alloc() -> miette::Result<()> {
     let compiler = common::default_compiler_from_path("input/compilation/alloc.ll")?;
     let flo = compiler.run()?;
 
-    // There should be a single function in the context.
-    assert_eq!(common::count_functions(&flo, false), 778);
+    // There should be 807 functions in the context.
+    assert_eq!(common::count_functions(&flo, false), 807);
 
     Ok(())
 }

--- a/crates/compiler/tests/compilation_compiler_builtins.rs
+++ b/crates/compiler/tests/compilation_compiler_builtins.rs
@@ -10,8 +10,8 @@ fn compiles_compiler_builtins() -> miette::Result<()> {
     let compiler = common::default_compiler_from_path("input/compilation/compiler_builtins.ll")?;
     let flo = compiler.run()?;
 
-    // There should be 1408 functions in the context.
-    assert_eq!(common::count_functions(&flo, false), 1408);
+    // There should be 2490 functions in the context.
+    assert_eq!(common::count_functions(&flo, false), 2490);
 
     Ok(())
 }

--- a/crates/compiler/tests/compilation_core.rs
+++ b/crates/compiler/tests/compilation_core.rs
@@ -10,8 +10,8 @@ fn compiles_core() -> miette::Result<()> {
     let compiler = common::default_compiler_from_path("input/compilation/core.ll")?;
     let flo = compiler.run()?;
 
-    // There should be 2678 functions in the context.
-    assert_eq!(common::count_functions(&flo, false), 2678);
+    // There should be 2812 functions in the context.
+    assert_eq!(common::count_functions(&flo, false), 2812);
 
     Ok(())
 }

--- a/crates/flo/src/types.rs
+++ b/crates/flo/src/types.rs
@@ -555,6 +555,7 @@ pub enum Type {
     Signed48,
     Signed64,
     Signed128,
+    Signed256,
 
     // Type for working with Cairo's built-in felt.
     // This is the only type considered weak -- it can accept or be assigned to any integer type.

--- a/crates/flo/tests/flo_test.rs
+++ b/crates/flo/tests/flo_test.rs
@@ -69,15 +69,19 @@ fn flos_are_the_same_after_round_trip() -> anyhow::Result<()> {
 
         // ... and perform the subtraction to compute i - 1.
         let i_minus_one = b.add_variable(Type::Unsigned32);
-        b.simple_call_builtin("sub_u32_u32", vec![fact_input, const_one], vec![
-            i_minus_one,
-        ]);
+        b.simple_call_builtin(
+            "sub_u32_u32",
+            vec![fact_input, const_one],
+            vec![i_minus_one],
+        );
 
         // Finally, we'll multiply i and i - 1...
         let final_value = b.add_variable(Type::Unsigned32);
-        b.simple_call_builtin("mul_u32_u32", vec![fact_input, i_minus_one], vec![
-            final_value,
-        ]);
+        b.simple_call_builtin(
+            "mul_u32_u32",
+            vec![fact_input, i_minus_one],
+            vec![final_value],
+        );
 
         // ... and return the result.
         b.end_with_return(vec![final_value]);

--- a/crates/mangler/src/mapping.rs
+++ b/crates/mangler/src/mapping.rs
@@ -98,6 +98,7 @@ pub fn mangle_type(typ: &Type) -> Result<String> {
         Type::Signed48 => "k",
         Type::Signed64 => "l",
         Type::Signed128 => "o",
+        Type::Signed256 => "y",
         Type::WeaklyTypedFelt => "w",
         Type::Half => "h",
         Type::Float => "f",

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1734331093,
-        "narHash": "sha256-9UrKDtqfLdsmDW4kRG/jSUAWot0jfL4WzcKA4nCvJZM=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e39e49f3314f7dd09671094dc640b528ba2b1e4b",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "nixpkgs": ["nixpkgs"]
       },
       "locked": {
-        "lastModified": 1733346208,
-        "narHash": "sha256-a4WZp1xQkrnA4BbnKrzJNr+dYoQr5Xneh2syJoddFyE=",
+        "lastModified": 1742901344,
+        "narHash": "sha256-o9dXcpfXpBm6+/SRqcQW0GzRkJymwyEAu5UD5LMDd3s=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "378614f37a6bee5a3f2ef4f825a73d948d3ae921",
+        "rev": "a75c0584b0d69de943babc899530e9c70c642b42",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734287558,
-        "narHash": "sha256-7DBZsPlP/9ZpYk+k6dLFG6SEH848HuGaY7ri/gdye4M=",
+        "lastModified": 1742296961,
+        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "27e824fad4cb40f9e475757871e7d259d73f20da",
+        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Summary

This commit bumps the version of the nightly compiler used to build the Rust core libraries. In doing so, a missing feature was discovered in the hieratika compiler.

To ensure that `core` and `compiler_builtins` continue to compile, support was implemented for `getelementptr` constant expressions in the compiler, ensuring that the project is not incompatible with newer versions of `rustc`.

As part of this work, we clarify the implementation of GEP to allow for negative offsets in arrays and from base pointers, which is supported by the spec.

# Details

Please carefully read the GEP stuff.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
