### PR TITLE
Bump rustc to 1.86.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: EmbarkStudios/cargo-deny-action@v2.0.4
+      - uses: EmbarkStudios/cargo-deny-action@v2.0.11
         with:
           manifest-path: ./Cargo.toml
           command: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,13 @@ authors = ["Reilabs"]
 keywords = ["compiler", "starknet", "starkware"]
 categories = ["compilers", "virtualization", "cryptography::cryptocurrencies"]
 
-edition = "2021"
-rust-version = "1.83.0"
+edition = "2024"
+rust-version = "1.86.0"
 
 # Dependencies that are used by more than one crate are specified here, allowing us to ensure that
 # we match versions in all crates.
 [workspace.dependencies]
 anyhow = "1.0.97"
-ariadne = "0.5.1"
 backtrace = "0.3.74"
 bimap = { version = "0.6.3", features = ["serde"] }
 cairo-lang-compiler = { path = "cairo/crates/cairo-lang-compiler" }

--- a/crates/cairoc/src/lib.rs
+++ b/crates/cairoc/src/lib.rs
@@ -106,10 +106,7 @@ fn get_flat_lowered_function(
     function_id: FunctionWithBodyId,
 ) -> Option<Arc<MultiLowering>> {
     print_compiler_diagnostics(db, function_id);
-    match db.priv_function_with_body_multi_lowering(function_id) {
-        Ok(f) => Some(f),
-        Err(_) => None,
-    }
+    db.priv_function_with_body_multi_lowering(function_id).ok()
 }
 
 /// This function returns the `FlatLowered` object of a Cairo program.
@@ -224,7 +221,7 @@ mod test {
                 let file = file.as_ref().unwrap();
                 if Path::new(file.file_name().to_str().unwrap())
                     .extension()
-                    .map_or(false, |ext| ext.eq_ignore_ascii_case("cairo"))
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("cairo"))
                 {
                     generate_flat_lowered(&file.path()).unwrap();
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,6 @@
 //! [`hieratika_cairoc`] crate and the [`hieratika_compiler`] crate.
 
 #![warn(clippy::all, clippy::cargo, clippy::pedantic)]
-#![expect(clippy::module_name_repetitions)] // Allows for better API naming
 
 use std::process;
 

--- a/crates/compiler/src/llvm/data_layout.rs
+++ b/crates/compiler/src/llvm/data_layout.rs
@@ -169,9 +169,9 @@ impl DataLayout {
             {
                 layout.nointptr_address_spaces = npa;
             } else if part.is_empty() {
-                // We don't know if empty parts are allowed, so we just behave permissively
-                // here. It cannot introduce any bugs to be permissive in this case.
-                continue;
+                // We don't know if empty parts are allowed, so we just behave
+                // permissively here. It cannot introduce any bugs to be
+                // permissive in this case.
             } else {
                 Err(Error::InvalidDataLayoutSpecification(
                     layout_string.to_string(),
@@ -304,7 +304,7 @@ impl DataLayout {
             self.integer_layouts
                 .iter()
                 .sorted_by_key(|l| l.size)
-                .last()
+                .next_back()
                 .expect("There must be at least one integer layout for the data layout to be valid")
         }
     }
@@ -489,7 +489,7 @@ impl PointerLayout {
                                  size {size}"
                             ),
                         ))?;
-                    };
+                    }
 
                     Ok(Self {
                         address_space,

--- a/crates/compiler/src/obj_gen/mod.rs
+++ b/crates/compiler/src/obj_gen/mod.rs
@@ -1229,10 +1229,12 @@ impl ObjectGenerator {
 
             // This should never fail by construction, so we bail with an error if somehow
             // it is.
-            let (mut next_extraction_var, next_extraction_type) =
-                output_variables.get(index).ok_or(Error::MalformedLLVM(format!(
+            let (mut next_extraction_var, next_extraction_type) = output_variables
+                .get(index)
+                .ok_or(Error::MalformedLLVM(format!(
                     "ExtractValue encountered with out-of-bounds index {index}"
-                )))?;
+                )))?
+                .clone();
 
             if count == num_indices - 1 {
                 next_extraction_var = target_var;
@@ -1247,7 +1249,7 @@ impl ObjectGenerator {
 
             // Finally, we update our state variables for the next iteration.
             current_extraction_var = next_extraction_var;
-            current_extraction_type = (*next_extraction_type).clone();
+            current_extraction_type = next_extraction_type.clone();
         }
 
         // We are done!
@@ -1275,7 +1277,7 @@ impl ObjectGenerator {
         func_ctx: &mut FunctionContext,
     ) -> Result<()> {
         fn compute_offset_const_type_size(
-            gen: &ObjectGenerator,
+            generator: &ObjectGenerator,
             gep_index: &BasicValueEnum,
             typ: &LLVMType,
             bb: &mut BlockBuilder,
@@ -1320,7 +1322,7 @@ impl ObjectGenerator {
                     &[LLVMType::i64, LLVMType::i64],
                     &LLVMType::i64,
                 )?;
-                let gep_index_offset = gen.get_var_or_const(gep_index, bb, func_ctx)?;
+                let gep_index_offset = generator.get_var_or_const(gep_index, bb, func_ctx)?;
                 let actual_offset = bb.add_variable(Type::Signed64);
                 bb.simple_call_builtin(
                     mul_func,
@@ -1597,7 +1599,7 @@ impl ObjectGenerator {
                 "Encountered a Store instruction attempting to store a value of type {typ}, but \
                  this is not valid"
             )))?,
-        };
+        }
 
         Ok(())
     }
@@ -1835,7 +1837,7 @@ impl ObjectGenerator {
                 "Encountered a Load instruction attempting to load a value of type {typ}, but \
                  this is not valid"
             )))?,
-        };
+        }
 
         Ok(())
     }

--- a/crates/flo/src/builders.rs
+++ b/crates/flo/src/builders.rs
@@ -219,7 +219,7 @@ impl<'a> BlockBuilder<'a> {
         // instructions.
         if let BlockExit::Goto { to, .. } = self.block.exit {
             self.block.exit = BlockExit::Goto { to, from: id }
-        };
+        }
 
         // We replace the block under that id with the block that has been newly built.
         self.context.blocks.swap(id, &self.block);

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
         fenixLib = fenix.packages.${system};
-        toolchainHash = "sha256-s1RPtyvDGJaX/BisLT+ifVfuhDT1nZkZ1NcK8sbwELM=";
+        toolchainHash = "sha256-X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
         fenixStable = fenixLib.fromToolchainName {
             name = rustVersion;
             sha256 = toolchainHash;


### PR DESCRIPTION
# Summary

I originally thought that this was required for bumping inkwell to 0.6.0 as an official version with LLVM 19 support, but I had misread the release notes and there is still no official LLVM 19 support. Still, the work was done, so I might as well PR it.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
