### PR TITLE
compiler-rt: alu: icmp: add pointer

### DIFF
--- a/compiler-rt/src/alu/icmp_eq.cairo
+++ b/compiler-rt/src/alu/icmp_eq.cairo
@@ -7,6 +7,7 @@ pub mod icmp_eq_i40;
 pub mod icmp_eq_i48;
 pub mod icmp_eq_i64;
 pub mod icmp_eq_i128;
+pub mod icmp_eq_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_eq/icmp_eq_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_eq/icmp_eq_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_eq::icmp_eq_i64::__llvm_icmp_eq_l_l_c;
+
+pub fn __llvm_icmp_eq_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_eq_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_ne.cairo
+++ b/compiler-rt/src/alu/icmp_ne.cairo
@@ -7,6 +7,7 @@ pub mod icmp_ne_i40;
 pub mod icmp_ne_i48;
 pub mod icmp_ne_i64;
 pub mod icmp_ne_i128;
+pub mod icmp_ne_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_ne/icmp_ne_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_ne/icmp_ne_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_ne::icmp_ne_i64::__llvm_icmp_ne_l_l_c;
+
+pub fn __llvm_icmp_ne_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_ne_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_sge.cairo
+++ b/compiler-rt/src/alu/icmp_sge.cairo
@@ -7,6 +7,7 @@ pub mod icmp_sge_i40;
 pub mod icmp_sge_i48;
 pub mod icmp_sge_i64;
 pub mod icmp_sge_i128;
+pub mod icmp_sge_ptr;
 
 use crate::alu::scmp::scmp;
 use core::num::traits::{BitSize, Bounded, OverflowingSub};

--- a/compiler-rt/src/alu/icmp_sge/icmp_sge_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_sge/icmp_sge_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_sge::icmp_sge_i64::__llvm_icmp_sge_l_l_c;
+
+pub fn __llvm_icmp_sge_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_sge_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_sgt.cairo
+++ b/compiler-rt/src/alu/icmp_sgt.cairo
@@ -7,6 +7,7 @@ pub mod icmp_sgt_i40;
 pub mod icmp_sgt_i48;
 pub mod icmp_sgt_i64;
 pub mod icmp_sgt_i128;
+pub mod icmp_sgt_ptr;
 
 use crate::alu::scmp::scmp;
 use core::num::traits::{BitSize, Bounded, OverflowingSub};

--- a/compiler-rt/src/alu/icmp_sgt/icmp_sgt_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_sgt/icmp_sgt_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_sgt::icmp_sgt_i64::__llvm_icmp_sgt_l_l_c;
+
+pub fn __llvm_icmp_sgt_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_sgt_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_sle.cairo
+++ b/compiler-rt/src/alu/icmp_sle.cairo
@@ -7,6 +7,7 @@ pub mod icmp_sle_i40;
 pub mod icmp_sle_i48;
 pub mod icmp_sle_i64;
 pub mod icmp_sle_i128;
+pub mod icmp_sle_ptr;
 
 use crate::alu::scmp::scmp;
 use core::num::traits::{BitSize, Bounded, OverflowingSub};

--- a/compiler-rt/src/alu/icmp_sle/icmp_sle_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_sle/icmp_sle_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_sle::icmp_sle_i64::__llvm_icmp_sle_l_l_c;
+
+pub fn __llvm_icmp_sle_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_sle_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_slt.cairo
+++ b/compiler-rt/src/alu/icmp_slt.cairo
@@ -7,6 +7,7 @@ pub mod icmp_slt_i40;
 pub mod icmp_slt_i48;
 pub mod icmp_slt_i64;
 pub mod icmp_slt_i128;
+pub mod icmp_slt_ptr;
 
 use crate::alu::scmp::scmp;
 use core::num::traits::{BitSize, Bounded, OverflowingSub};

--- a/compiler-rt/src/alu/icmp_slt/icmp_slt_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_slt/icmp_slt_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_slt::icmp_slt_i64::__llvm_icmp_slt_l_l_c;
+
+pub fn __llvm_icmp_slt_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_slt_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_uge.cairo
+++ b/compiler-rt/src/alu/icmp_uge.cairo
@@ -7,6 +7,7 @@ pub mod icmp_uge_i40;
 pub mod icmp_uge_i48;
 pub mod icmp_uge_i64;
 pub mod icmp_uge_i128;
+pub mod icmp_uge_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_uge/icmp_uge_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_uge/icmp_uge_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_uge::icmp_uge_i64::__llvm_icmp_uge_l_l_c;
+
+pub fn __llvm_icmp_uge_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_uge_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_ugt.cairo
+++ b/compiler-rt/src/alu/icmp_ugt.cairo
@@ -7,6 +7,7 @@ pub mod icmp_ugt_i40;
 pub mod icmp_ugt_i48;
 pub mod icmp_ugt_i64;
 pub mod icmp_ugt_i128;
+pub mod icmp_ugt_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_ugt/icmp_ugt_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_ugt/icmp_ugt_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_ugt::icmp_ugt_i64::__llvm_icmp_ugt_l_l_c;
+
+pub fn __llvm_icmp_ugt_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_ugt_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_ule.cairo
+++ b/compiler-rt/src/alu/icmp_ule.cairo
@@ -7,6 +7,7 @@ pub mod icmp_ule_i40;
 pub mod icmp_ule_i48;
 pub mod icmp_ule_i64;
 pub mod icmp_ule_i128;
+pub mod icmp_ule_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_ule/icmp_ule_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_ule/icmp_ule_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_ule::icmp_ule_i64::__llvm_icmp_ule_l_l_c;
+
+pub fn __llvm_icmp_ule_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_ule_l_l_c(lhs, rhs)
+}

--- a/compiler-rt/src/alu/icmp_ult.cairo
+++ b/compiler-rt/src/alu/icmp_ult.cairo
@@ -7,6 +7,7 @@ pub mod icmp_ult_i40;
 pub mod icmp_ult_i48;
 pub mod icmp_ult_i64;
 pub mod icmp_ult_i128;
+pub mod icmp_ult_ptr;
 
 use crate::utils::assert_fits_in_type;
 use core::num::traits::{BitSize, Bounded};

--- a/compiler-rt/src/alu/icmp_ult/icmp_ult_ptr.cairo
+++ b/compiler-rt/src/alu/icmp_ult/icmp_ult_ptr.cairo
@@ -1,0 +1,7 @@
+use crate::alu::icmp_ult::icmp_ult_i64::__llvm_icmp_ult_l_l_c;
+
+pub fn __llvm_icmp_ult_p_p_c(lhs: u128, rhs: u128) -> u128 {
+    // Addresses are implemented as 64-bit integers (see `compiler-rt::crt0::allocator`).
+    // Therefore, this function is just a wrapper over the 64-bit implementation of this operation.
+    __llvm_icmp_ult_l_l_c(lhs, rhs)
+}


### PR DESCRIPTION
# Summary

Implement icmp_<op>_p_p_c set of polyfills, comparing pointers as if they were integers. Since we implement pointers as u64, these polyfills are just wrappers on the existing 64b polyfills.

# Details

It's the simplest compiler-rt addition ever. Every `icmp_<op>` gets `__llvm_icmp_<op>_p_p_c()` which is a wrapper over `_l_l_c()` of the same `icmp` mode, because, as per LLVM Language Reference:

> If the operands are pointer-typed, the pointer values are compared as if they were integers.

and our allocator implements addresses as u64, therefore these new functions are wrapper over u64 comparisons.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
