### PR TITLE
compiler-rt: implement load/store for bool and ptr

### DIFF
--- a/compiler-rt/src/crt0/memory/load.cairo
+++ b/compiler-rt/src/crt0/memory/load.cairo
@@ -116,6 +116,21 @@ mod test {
     }
 }
 
+pub fn __llvm_load_p_l_c(address: Address, offset: i64) -> bool {
+    // As per LLVM Languge Reference:
+    //  When loading a value of a type like i20 with a size that is not an integral number of bytes,
+    //  the result is undefined if the value was not originally written using a store of the same
+    //  type
+    //
+    // Therefore, in this implementation loading a bool will load 1 byte of data and only LSB will
+    // be returned. The remaining bits will be ignored.
+    if __llvm_load_p_l_b(address, offset) & 0b1 == 0b1 {
+        return true;
+    }
+
+    return false;
+}
+
 pub fn __llvm_load_p_l_b(address: Address, offset: i64) -> u8 {
     let mut allocator = get_allocator().unbox();
     load::<u8>(ref allocator, address, offset)
@@ -149,6 +164,11 @@ pub fn __llvm_load_p_l_k(address: Address, offset: i64) -> u48 {
 pub fn __llvm_load_p_l_l(address: Address, offset: i64) -> u64 {
     let mut allocator = get_allocator().unbox();
     load::<u64>(ref allocator, address, offset)
+}
+
+pub fn __llvm_load_p_l_p(address: Address, offset: i64) -> Address {
+    // Address is a 64-bit integer, so we can use the u64 implementation.
+    __llvm_load_p_l_l(address, offset)
 }
 
 pub fn __llvm_load_p_l_o(address: Address, offset: i64) -> u128 {

--- a/compiler-rt/src/crt0/memory/store.cairo
+++ b/compiler-rt/src/crt0/memory/store.cairo
@@ -132,6 +132,22 @@ mod test {
     }
 }
 
+pub fn __llvm_store_c_p_l_v(value: bool, address: Address, offset: i64) {
+    // As per LLVM Languge Reference:
+    //   When writing a value of a type like i20 with a size that is not an integral number of
+    //   bytes, it is unspecified what happens to the extra bits that do not belong to the type, but
+    //   they will typically be overwritten
+    //
+    // Therefore, in this implementation writing a bool will write 1 byte of data, and the
+    // remaining bits will be set to 0.
+    let value: u8 = if value {
+        1
+    } else {
+        0
+    };
+    __llvm_store_b_p_l_v(value, address, offset);
+}
+
 pub fn __llvm_store_b_p_l_v(value: u8, address: Address, offset: i64) {
     let mut allocator = get_allocator().unbox();
     store(ref allocator, value, address, offset);
@@ -167,8 +183,12 @@ pub fn __llvm_store_l_p_l_v(value: u64, address: Address, offset: i64) {
     store(ref allocator, value, address, offset);
 }
 
+pub fn __llvm_store_p_p_l_v(value: Address, address: Address, offset: i64) {
+    // Address is a 64-bit integer, so we can use the u64 implementation.
+    __llvm_store_l_p_l_v(value, address, offset);
+}
+
 pub fn __llvm_store_o_p_l_v(value: u128, address: Address, offset: i64) {
     let mut allocator = get_allocator().unbox();
     store(ref allocator, value, address, offset);
 }
-


### PR DESCRIPTION
# Summary

Implement the following polyfills:
- `__llvm_load_p_l_c` (this is really `__llvm_load_p_l_b`)
- `__llvm_load_p_l_p` (this is really `__llvm_load_p_l_l`)
- `__llvm_store_c_p_l_v` (this is really `__llvm_store_b_p_l_v`)
- `__llvm_store_p_p_l_v` (this is really `__llvm_store_l_p_l_v`)

They're wrappers because `p == l` and `c == b`.

# Details

At first I thought I also need to implement  `__llvm_load_p_l_{d,f,h,q}` and `__llvm_store_{d,f,h,q}_p_l_v`, but they operate on floats and we don't have floats, hence this PR is tiny.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
