### PR TITLE
Add a Cairo-compatible mangling scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ version = "0.1.0"
 dependencies = [
  "hieratika-errors",
  "hieratika-flo",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ hieratika-flo = { path = "crates/flo" }
 hieratika-mangler = { path = "crates/mangler" }
 hieratika-test-utils = { path = "crates/test-utils" }
 miette = { version = "7.5.0", features = ["fancy"] }
+regex = "1.11.1"
 starknet-types-core = "0.1.7"
 thiserror = "2.0.12"
 hieratika-lifter = { path = "crates/lifter" }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -29,4 +29,4 @@ rand = "0.9.0"
 
 [dev-dependencies]
 anyhow.workspace = true
-regex = "1.11.1"
+regex.workspace = true

--- a/crates/compiler/src/obj_gen/data.rs
+++ b/crates/compiler/src/obj_gen/data.rs
@@ -17,7 +17,7 @@ use hieratika_flo::{
         VariableLinkage,
     },
 };
-use hieratika_mangler::{NameInfo, constants::INTERNAL_NAME_PREFIX, mangle};
+use hieratika_mangler::{NameInfo, constants::INTERNAL_NAME_PREFIX, mangle_cairo};
 use inkwell::module::Linkage;
 
 use crate::{
@@ -156,7 +156,7 @@ impl ObjectContext {
     /// let local_dispatch_name =
     ///     ObjectContext::local_dispatch_name_for(&function_type, module_name).unwrap();
     ///
-    /// assert_eq!(local_dispatch_name, "__f$hdisp$co$my_module");
+    /// assert_eq!(local_dispatch_name, "__f___hdisp___co___my_module");
     /// ```
     ///
     /// # Errors
@@ -176,7 +176,7 @@ impl ObjectContext {
             .collect::<Result<Vec<_>>>()?;
         let return_types = vec![Self::flo_type_of(typ.return_type.as_ref())?];
         let mangle_input = NameInfo::new(&func_name, module_name, input_types, return_types);
-        let mangled_name = mangle(mangle_input).unwrap_or_else(|_| panic_cannot_mangle(typ));
+        let mangled_name = mangle_cairo(mangle_input).unwrap_or_else(|_| panic_cannot_mangle(typ));
 
         Ok(mangled_name)
     }
@@ -196,7 +196,7 @@ impl ObjectContext {
     /// let function_type = LLVMFunction::new(LLVMType::f32, &[LLVMType::bool, LLVMType::i128]);
     /// let global_dispatch_name = ObjectContext::global_dispatch_name_for(&function_type).unwrap();
     ///
-    /// assert_eq!(global_dispatch_name, "__f$hdisp$co$meta");
+    /// assert_eq!(global_dispatch_name, "__f___hdisp___co___meta");
     /// ```
     ///
     /// # Errors
@@ -221,7 +221,7 @@ impl ObjectContext {
             input_types,
             return_types,
         );
-        let mangled_name = mangle(mangle_input).unwrap_or_else(|_| panic_cannot_mangle(typ));
+        let mangled_name = mangle_cairo(mangle_input).unwrap_or_else(|_| panic_cannot_mangle(typ));
 
         Ok(mangled_name)
     }

--- a/crates/mangler/Cargo.toml
+++ b/crates/mangler/Cargo.toml
@@ -16,5 +16,6 @@ rust-version.workspace = true
 [dependencies]
 hieratika-errors.workspace = true
 hieratika-flo.workspace = true
+regex.workspace = true
 
 [dev-dependencies]

--- a/crates/mangler/src/constants.rs
+++ b/crates/mangler/src/constants.rs
@@ -1,8 +1,20 @@
 //! This module contains constants that specify portions of the mangling
 //! behavior.
 
+use std::sync::LazyLock;
+
+use regex::Regex;
+
 /// A marker used to separate sections in the mangled string.
 pub const SECTION_SEPARATOR: &str = "$";
+
+/// A marker used to separate sections in the mangled string when compatibility
+/// with source-level Cairo is required.
+pub const SECTION_SEPARATOR_CAIRO: &str = "___";
+
+/// A marker used to replace a character in any user-provided string for
+/// mangling that is disallowed in a Cairo identifier.
+pub const INVALID_CAIRO_CHARACTER: &str = "_IC_";
 
 /// A marker used to signify the beginning of a snapshot mangle segment.
 pub const BEGIN_SNAPSHOT: &str = "m";
@@ -24,3 +36,8 @@ pub const END_ENUM: &str = "g";
 
 /// The prefix for symbols that indicates that they are internal or reserved.
 pub const INTERNAL_NAME_PREFIX: &str = "__";
+
+/// The regex that matches on characters that are invalid to have in a Cairo
+/// identifier.
+pub static INVALID_CAIRO_CHARS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("[^[A-Za-z0-9_-]]").expect("Hardcoded regex was not valid"));

--- a/crates/mangler/src/lib.rs
+++ b/crates/mangler/src/lib.rs
@@ -22,7 +22,13 @@ mod util;
 use hieratika_flo::types::Type;
 
 use crate::{
-    constants::{INTERNAL_NAME_PREFIX, SECTION_SEPARATOR},
+    constants::{
+        INTERNAL_NAME_PREFIX,
+        INVALID_CAIRO_CHARACTER,
+        INVALID_CAIRO_CHARS_REGEX,
+        SECTION_SEPARATOR,
+        SECTION_SEPARATOR_CAIRO,
+    },
     mapping::{mangle_params, mangle_returns},
 };
 
@@ -82,6 +88,103 @@ pub fn mangle(name: NameInfo) -> Result<String> {
     let trimmed_name = name.name.trim_start_matches(INTERNAL_NAME_PREFIX).into();
     let combined =
         [returns_string, trimmed_name, params_string, func_module].join(SECTION_SEPARATOR);
+    if name.name.starts_with(INTERNAL_NAME_PREFIX) {
+        Ok(format!("{INTERNAL_NAME_PREFIX}{combined}"))
+    } else {
+        Ok(combined)
+    }
+}
+
+/// Generates the mangled form of the provided `name` in a form that is
+/// compatible with source-cairo's naming conventions.
+///
+/// A mangled name consists of the return types string, followed by the function
+/// name, followed by the params string, followed by the function's module, all
+/// separated using the [`SECTION_SEPARATOR_CAIRO`].
+///
+/// ```
+/// use hieratika_flo::types::Type;
+/// use hieratika_mangler::{NameInfo, mangle_cairo};
+///
+/// let func_name = NameInfo::new(
+///     "my_func",
+///     "my_module",
+///     vec![Type::Double, Type::Bool],
+///     vec![Type::Float, Type::Bool],
+/// );
+///
+/// assert_eq!(
+///     mangle_cairo(func_name).unwrap(),
+///     "fc___my_func___dc___my_module"
+/// );
+/// ```
+///
+/// If the provided function name is internal or reserved (in other words that
+/// it begins with [`INTERNAL_NAME_PREFIX`]), the output name will also begin
+/// with the same prefix. Note that the prefix will be stripped from the start
+/// of the provided name, ensuring a more compact representation.
+///
+/// ```
+/// use hieratika_flo::types::Type;
+/// use hieratika_mangler::{NameInfo, mangle_cairo};
+///
+/// let func_name = NameInfo::new(
+///     "__my_func",
+///     "my_module",
+///     vec![Type::Double, Type::Bool],
+///     vec![Type::Float, Type::Bool],
+/// );
+///
+/// assert_eq!(
+///     mangle_cairo(func_name).unwrap(),
+///     "__fc___my_func___dc___my_module"
+/// );
+/// ```
+///
+/// If the provided module name or function name contain disallowed characters,
+/// these are replaced with [`INVALID_CAIRO_CHARACTER`].
+///
+/// ```
+/// use hieratika_flo::types::Type;
+/// use hieratika_mangler::{NameInfo, mangle_cairo};
+///
+/// let func_name = NameInfo::new(
+///     "__my_func&illegal",
+///     "my_module_with$illegal$chars",
+///     vec![Type::Double, Type::Bool],
+///     vec![Type::Float, Type::Bool],
+/// );
+///
+/// assert_eq!(
+///     mangle_cairo(func_name).unwrap(),
+///     "__fc___my_func_IC_illegal___dc___my_module_with_IC_illegal_IC_chars"
+/// );
+/// ```
+///
+/// # Errors
+///
+/// - [`Error::InvalidInput`] if any of the types in the input `name` cannot be
+///   mangled.
+///
+/// # Panics
+///
+/// - If the hard-coded regex for disallowed characters cannot be constructed.
+#[expect(clippy::needless_pass_by_value)] // Ensures API uniformity
+pub fn mangle_cairo(name: NameInfo) -> Result<String> {
+    let returns_string = mangle_returns(&name.return_types)?;
+    let params_string = mangle_params(&name.parameter_types)?;
+    let func_module = INVALID_CAIRO_CHARS_REGEX.replace_all(&name.module, INVALID_CAIRO_CHARACTER);
+    let trimmed_name = INVALID_CAIRO_CHARS_REGEX.replace_all(
+        name.name.trim_start_matches(INTERNAL_NAME_PREFIX),
+        INVALID_CAIRO_CHARACTER,
+    );
+    let combined = [
+        returns_string,
+        trimmed_name.to_string(),
+        params_string,
+        func_module.to_string(),
+    ]
+    .join(SECTION_SEPARATOR_CAIRO);
     if name.name.starts_with(INTERNAL_NAME_PREFIX) {
         Ok(format!("{INTERNAL_NAME_PREFIX}{combined}"))
     } else {


### PR DESCRIPTION
# Summary

The previous mangling scheme was intended to operate purely in FLO and Sierra which do not have any care for the way things are named. In the interests of boxing the work to getting something running, we are instead hoping to target source Cairo, which requires our naming scheme to be compatible with Cairo names. This new mangling scheme accounts for that case.

# Details

Please do suggest a better idea for replacing invalid characters. The current `_IC_` is very ugly. `___` for separation is pretty ugly too.

# Checklist

- [x] Code is formatted by Rustfmt or `scarb fmt`.
- [x] Documentation has been updated if necessary.
